### PR TITLE
Fix empty charts when a single activity/program facet is selected

### DIFF
--- a/utilities/ChartableMetrics.ts
+++ b/utilities/ChartableMetrics.ts
@@ -150,9 +150,20 @@ export function toChartableDataset(
 
   // Pivot in the budget/actuals.
   // Do not collapse the two getDataColumnNames() calls as data is modifieid.
+  //
+  // The _pivot_name_hack_ dummy value column forces arquero to emit
+  // value-prefixed column names (`<col>_budget`) even when only a single
+  // value column is present. Without it, a lone value column (e.g. a
+  // single selected activity/program facet) pivots to bare
+  // `budget`/`actuals` columns, which the chart's
+  // `<metricColumn>_<facet>_<key>` lookup can't find, so the chart
+  // renders empty. The hack columns are stripped immediately after.
+  const valueColumns = getDataColumnNames(prefixedData);
   const data = prefixedData
+    .derive({ _pivot_name_hack_: () => 0 })
     .groupby("class_of")
-    .pivot("data_type", getDataColumnNames(prefixedData))
+    .pivot("data_type", [...valueColumns, "_pivot_name_hack_"])
+    .select(aq.not(aq.startswith("_pivot_name_hack_")))
     .orderby("class_of");
 
   return data;


### PR DESCRIPTION
toChartableDataset's data_type pivot dropped arquero's value-column prefix when only one value column was present (a single selected facet), emitting bare `budget`/`actuals` columns. The chart's `<metricColumn>_<facet>_<key>` lookup then matched nothing and the chart rendered empty; 2+ selections worked because the prefixed naming kicked in.

Add a dummy `_pivot_name_hack_` value column before the pivot to force consistent value-prefixed naming, then strip it — the same technique already used on the facet pivot in toFacetedCharatbleDataset.