### PR TITLE
Add a Salaries dashboard: every S-275 salary, by duty title

### DIFF
--- a/app/finance/_widgets/FinanceSubNav.tsx
+++ b/app/finance/_widgets/FinanceSubNav.tsx
@@ -29,6 +29,7 @@ export default function FinanceSubNav({ sx = [] }: Params) {
         <NavLink href={"/finance/revenues"}>Revenues</NavLink>
         <NavLink href={"/finance/detailedactuals"}>Detailed Actuals</NavLink>
         <NavLink href={"/finance/staffing"}>Staffing</NavLink>
+        <NavLink href={"/finance/salaries"}>Salaries</NavLink>
         <NavLink href={"/finance/correlations"}>Correlations</NavLink>
       </Stack>
     </Toolbar>

--- a/app/finance/salaries/SalariesPage.tsx
+++ b/app/finance/salaries/SalariesPage.tsx
@@ -1,0 +1,189 @@
+"use client";
+
+// Salaries dashboard: every S-275 total_final_salary for one district and year,
+// one column per person, grouped by duty title and wrapped across rows.
+//
+// This page fetches `s275_salaries` itself rather than going through
+// DistrictData. That dataset is one row per employee (~7k rows per year for
+// SPS, ~86k across all years) and only this page needs it, so loading it in
+// the shared provider would put it on the wire for every finance dashboard.
+
+import Alert from "@mui/material/Alert";
+import Box from "@mui/material/Box";
+import CircularProgress from "@mui/material/CircularProgress";
+import Link from "@mui/material/Link";
+import MenuItem from "@mui/material/MenuItem";
+import Stack from "@mui/material/Stack";
+import TextField from "@mui/material/TextField";
+import Typography from "@mui/material/Typography";
+import { useEffect, useMemo, useState } from "react";
+
+import DistrictSelector from "app/finance/_widgets/DistrictSelector";
+import FinanceSubNav from "app/finance/_widgets/FinanceSubNav";
+import { fetchDataset } from "utilities/client/FetchData";
+
+import SalarySkyline from "./SalarySkyline";
+import { groupByDuty, planRows } from "./rowPlan";
+
+import type { Person } from "./rowPlan";
+
+const SPS_CCDDD = 17001;
+const PEOPLE_PER_ROW = 1500;
+
+type Result = { ccddd: number; rows: Record[] | null };
+
+type Record = {
+  school_year: string;
+  duty_root: string | null;
+  duty_root_code: number | null;
+  total_final_salary: unknown;
+  fte: unknown;
+};
+
+// Arquero hands numeric columns back as Decimal wrappers or plain numbers
+// depending on the Avro logical type, so normalize before arithmetic.
+function num(v: unknown): number {
+  if (v === null || v === undefined) return 0;
+  if (typeof v === "number") return v;
+  const maybe = v as { toNumber?: () => number };
+  return typeof maybe.toNumber === "function" ? maybe.toNumber() : Number(v);
+}
+
+export default function SalariesPage() {
+  const [ccddd, setCcddd] = useState(SPS_CCDDD);
+  // The fetch result carries the district it belongs to, so a stale result
+  // for the previous district reads as "still loading" without an effect
+  // having to synchronously clear state on every change.
+  const [result, setResult] = useState<Result | null>(null);
+  const [yearChoice, setYearChoice] = useState<string | null>(null);
+
+  useEffect(() => {
+    let live = true;
+    fetchDataset(ccddd, "s275_salaries")
+      .then((table) => {
+        if (live) setResult({ ccddd, rows: table.objects() as Record[] });
+      })
+      .catch((err) => {
+        if (!live) return;
+        console.error("s275_salaries fetch failed", err);
+        setResult({ ccddd, rows: null });
+      });
+    return () => {
+      live = false;
+    };
+  }, [ccddd]);
+
+  const current = result?.ccddd === ccddd ? result : null;
+  const rows = current?.rows ?? null;
+  const failed = current !== null && current.rows === null;
+
+  const years = useMemo(() => {
+    if (!rows) return [];
+    return [...new Set(rows.map((r) => r.school_year))].sort().reverse();
+  }, [rows]);
+
+  // Derived rather than stored: the newest year is the default, and a year
+  // the current district has no filings for falls back to that default
+  // instead of needing an effect to correct it.
+  const year =
+    yearChoice && years.includes(yearChoice) ? yearChoice : (years[0] ?? "");
+
+  const people: Person[] = useMemo(() => {
+    if (!rows || !year) return [];
+    return rows
+      .filter((r) => r.school_year === year)
+      .map((r) => ({
+        duty: r.duty_root ?? `Duty ${r.duty_root_code ?? "unknown"}`,
+        salary: num(r.total_final_salary),
+        fte: num(r.fte),
+      }))
+      .filter((p) => p.salary > 0);
+  }, [rows, year]);
+
+  const plan = useMemo(() => planRows(people, PEOPLE_PER_ROW), [people]);
+
+  const colorOf = useMemo(() => {
+    const map = new Map<string, number>();
+    let i = 0;
+    for (const duty of groupByDuty(people).keys()) map.set(duty, i++);
+    return map;
+  }, [people]);
+
+  const payroll = people.reduce((sum, p) => sum + p.salary, 0);
+  const fte = people.reduce((sum, p) => sum + p.fte, 0);
+
+  return (
+    <>
+      <FinanceSubNav />
+      <Box sx={{ p: 3 }}>
+        <Typography component="h1" variant="h4" gutterBottom>
+          Salaries
+        </Typography>
+        <Typography variant="body2" sx={{ color: "text.secondary", mb: 2 }}>
+          Every S-275 <code>total_final_salary</code> for the year, one column
+          per person, grouped by the duty title of their major assignment and
+          sorted by salary within each duty. Rows wrap; every row shares the
+          same salary scale and the same number of slots, so heights and
+          horizontal positions are comparable between them. A variant of the{" "}
+          <Link href="/analyses/seattle_sea_pay_gap.html">
+            SEA pay-gap analysis
+          </Link>{" "}
+          chart.
+        </Typography>
+
+        <Stack direction="row" spacing={2} sx={{ mb: 2, flexWrap: "wrap" }}>
+          <DistrictSelector
+            ccddd={ccddd}
+            onChange={setCcddd}
+            sx={{ minWidth: 320 }}
+          />
+          <TextField
+            select
+            size="small"
+            label="School year"
+            value={year}
+            onChange={(e) => setYearChoice(e.target.value)}
+            disabled={years.length === 0}
+            sx={{ minWidth: 160 }}
+          >
+            {years.map((y) => (
+              <MenuItem key={y} value={y}>
+                {y}
+              </MenuItem>
+            ))}
+          </TextField>
+        </Stack>
+
+        {failed && (
+          <Alert severity="info" sx={{ mb: 2 }}>
+            The per-employee salary dataset is not available for this district
+            yet. The <code>s275_salaries</code> dataset needs the Cloud Function
+            deployed (<code>cd functions && npm run deploy</code>); until then
+            this page has nothing per-person to draw.
+          </Alert>
+        )}
+
+        {!current && (
+          <Stack direction="row" spacing={1} alignItems="center">
+            <CircularProgress size={18} />
+            <Typography variant="body2">Loading salaries…</Typography>
+          </Stack>
+        )}
+
+        {rows && people.length > 0 && (
+          <>
+            <Typography variant="body2" sx={{ mb: 1.5 }}>
+              <b>{people.length.toLocaleString()}</b> people ·{" "}
+              <b>
+                {fte.toLocaleString(undefined, { maximumFractionDigits: 0 })}
+              </b>{" "}
+              FTE · <b>${(payroll / 1e6).toFixed(1)}M</b> in salaries ·{" "}
+              {colorOf.size} duty titles
+            </Typography>
+            <SalarySkyline plan={plan} colorOf={colorOf} year={year} />
+          </>
+        )}
+      </Box>
+    </>
+  );
+}

--- a/app/finance/salaries/SalarySkyline.tsx
+++ b/app/finance/salaries/SalarySkyline.tsx
@@ -1,0 +1,298 @@
+"use client";
+
+// The salary skyline: one column per employee, height their total_final_salary,
+// grouped by duty title and wrapped across rows.
+//
+// Each row is its own Highcharts chart sharing one y-axis maximum and one
+// x-axis slot count, so heights and horizontal positions are comparable
+// between rows.
+//
+// The columns are drawn as a stepped area per duty rather than a column
+// series. At ~1,500 people across ~1,400px a column is under a pixel wide, so
+// the two are pixel-identical, but a column series emits one SVG path per
+// person -- 7,156 of them for SPS 2024-25, enough to lock the main thread for
+// tens of seconds. Stepping an area over the same points draws one path per
+// duty instead, while keeping a point per person so tooltips still resolve to
+// an individual.
+
+import Box from "@mui/material/Box";
+import Typography from "@mui/material/Typography";
+import { useEffect, useRef } from "react";
+
+import { useHighcharts } from "components/providers/HighchartsProvider";
+
+import type { Plan, Row } from "./rowPlan";
+
+// Duty titles are colored only to separate neighbours; the palette is the
+// CVD-safe one used by the Sankey pages.
+const PALETTE = [
+  "#0072B2",
+  "#D55E00",
+  "#009E73",
+  "#CC79A7",
+  "#56B4E9",
+  "#E69F00",
+  "#7A5195",
+  "#4C6472",
+];
+
+const ROW_HEIGHT = 190;
+// Plot-area insets; the HTML label strip has to line up with these.
+const PLOT_LEFT = 62;
+const PLOT_RIGHT = 12;
+
+const money = (v: number) =>
+  v >= 1e6 ? `$${(v / 1e6).toFixed(1)}M` : `$${Math.round(v / 1000)}k`;
+
+type Props = {
+  plan: Plan;
+  /** Stable duty -> palette index, so a duty keeps its color across rows. */
+  colorOf: Map<string, number>;
+  year: string;
+};
+
+function rowOptions(
+  row: Row,
+  plan: Plan,
+  colorOf: Map<string, number>,
+  isFirst: boolean,
+) {
+  // Color is set two ways on purpose. The app loads Highcharts' styled-mode
+  // CSS, whose `.highcharts-color-N { fill: var(--highcharts-color-N) }` rule
+  // lands on the series <g>; an area series then puts its own fill on the
+  // <path> inside, which wins, while a column series inherits from the <g>,
+  // where the CSS wins. Setting `color` and the colorIndex, with
+  // SalarySkyline rebinding --highcharts-color-N to the same palette, gives
+  // the same result whichever one takes effect.
+  const series = row.segments.map((seg) => ({
+    type: "area" as const,
+    step: "left" as const,
+    name: seg.label,
+    color: PALETTE[(colorOf.get(seg.duty) ?? 0) % PALETTE.length],
+    colorIndex: (colorOf.get(seg.duty) ?? 0) % PALETTE.length,
+    // Explicit x keeps each segment in its own slot range, so a partly filled
+    // final row stops where it stops instead of stretching to full width.
+    data: seg.people.map((p, i) => ({
+      x: seg.start + i,
+      y: p.salary,
+      fte: p.fte,
+      duty: seg.duty,
+    })),
+  }));
+
+  return {
+    chart: {
+      type: "area",
+      height: ROW_HEIGHT,
+      marginTop: 6,
+      marginLeft: PLOT_LEFT,
+      marginRight: PLOT_RIGHT,
+      animation: false,
+      spacingBottom: 6,
+    },
+    title: { text: undefined },
+    credits: { enabled: false },
+    legend: { enabled: false },
+    accessibility: {
+      description:
+        `Salaries for people ${row.offset + 1} to ${row.offset + row.filled} ` +
+        `of ${plan.totalPeople}, by duty title, tallest first.`,
+    },
+    xAxis: {
+      min: -0.5,
+      max: plan.slotsPerRow - 0.5,
+      tickLength: 0,
+      lineColor: "#bbb",
+      labels: { enabled: false },
+    },
+    yAxis: {
+      // Shared across rows: heights only mean something if the scale is fixed.
+      min: 0,
+      max: plan.maxSalary,
+      title: { text: undefined },
+      gridLineColor: "#eee",
+      labels: {
+        formatter(this: { value: number }) {
+          return money(this.value);
+        },
+        style: { color: "#888", fontSize: "10.5px" },
+      },
+    },
+    plotOptions: {
+      area: {
+        // Fill to the axis, no outline and no markers: the silhouette is the
+        // chart, and a marker per person would put the 7k elements back. The
+        // hover marker is the exception -- it is drawn one at a time, and it
+        // is what shows which individual the tooltip is quoting.
+        threshold: 0,
+        fillOpacity: 1,
+        lineWidth: 0,
+        marker: {
+          enabled: false,
+          states: { hover: { enabled: true, radius: 3 } },
+        },
+        animation: false,
+        crisp: false,
+      },
+      series: {
+        // Nearest-point tracking. Columns here are sub-pixel, so requiring an
+        // exact hit would make the tooltip unreachable.
+        stickyTracking: true,
+        // Rows carry ~1,500 points, well past the default 1,000 turbo
+        // threshold, beyond which Highcharts only accepts bare numbers and
+        // silently drops the per-point FTE / duty the tooltip reads.
+        turboThreshold: 0,
+      },
+    },
+    tooltip: {
+      // The height is the paycheck; FTE and the implied rate are what the
+      // height alone cannot tell you, so both ride along.
+      useHTML: true,
+      formatter(this: { y: number; point: { fte: number; duty: string } }) {
+        const fte = this.point.fte;
+        const rate = fte > 0 ? this.y / fte : null;
+        return (
+          `<b>$${Math.round(this.y).toLocaleString()}</b><br>` +
+          `${this.point.duty}<br>` +
+          `${fte.toFixed(2)} FTE` +
+          (rate === null ? "" : ` · $${Math.round(rate).toLocaleString()}/FTE`)
+        );
+      },
+    },
+    series,
+    exporting: { enabled: isFirst },
+  };
+}
+
+export default function SalarySkyline({ plan, colorOf, year }: Props) {
+  const { highchartsObjs } = useHighcharts();
+  const hostRefs = useRef<Array<HTMLDivElement | null>>([]);
+
+  useEffect(() => {
+    const highcharts = highchartsObjs?.highcharts;
+    if (!highcharts) return;
+
+    // A district-year is one column per employee -- 7,156 SVG paths for SPS
+    // 2024-25. Building every row up front locks the main thread for tens of
+    // seconds, so each row is drawn only once it is near the viewport, and
+    // the rows below stay empty boxes of the right height until then.
+    const charts = new Map<number, { destroy: () => void }>();
+    const draw = (i: number) => {
+      const host = hostRefs.current[i];
+      if (!host || charts.has(i)) return;
+      charts.set(
+        i,
+        highcharts.chart(
+          host,
+          rowOptions(plan.rows[i], plan, colorOf, i === 0),
+        ),
+      );
+    };
+
+    let observer: IntersectionObserver | null = null;
+    if (typeof IntersectionObserver === "undefined") {
+      plan.rows.forEach((_row, i) => draw(i));
+    } else {
+      observer = new IntersectionObserver(
+        (entries, obs) => {
+          for (const entry of entries) {
+            if (!entry.isIntersecting) continue;
+            const i = Number((entry.target as HTMLElement).dataset.row);
+            draw(i);
+            obs.unobserve(entry.target);
+          }
+        },
+        // A screen of lead time, so a row is usually ready by the time it
+        // scrolls in.
+        { rootMargin: "600px 0px" },
+      );
+      for (const host of hostRefs.current) if (host) observer.observe(host);
+    }
+
+    return () => {
+      observer?.disconnect();
+      for (const chart of charts.values()) chart.destroy();
+    };
+  }, [highchartsObjs, plan, colorOf]);
+
+  if (plan.rows.length === 0) {
+    return (
+      <Typography variant="body2" sx={{ color: "text.secondary" }}>
+        No S-275 salaries on file for {year}.
+      </Typography>
+    );
+  }
+
+  const paletteVars = Object.fromEntries(
+    PALETTE.map((c, i) => [`--highcharts-color-${i}`, c]),
+  ) as React.CSSProperties;
+
+  return (
+    <Box sx={paletteVars}>
+      {plan.rows.map((row, i) => (
+        <Box key={i} sx={{ mb: 1 }}>
+          {/*
+            Duty labels are HTML rather than Highcharts plot-band labels. The
+            app's styled-mode CSS overrides plot-band fills (a transparent band
+            computes to black), and positioning them here also lets narrow
+            duties drop their label instead of overlapping a neighbour's.
+            Percentages are taken across the plot area, so they stay aligned
+            with the columns when the chart resizes.
+          */}
+          <Box
+            sx={{
+              position: "relative",
+              height: 20,
+              ml: `${PLOT_LEFT}px`,
+              mr: `${PLOT_RIGHT}px`,
+            }}
+          >
+            {row.segments.map((seg) => {
+              const left = (seg.start / plan.slotsPerRow) * 100;
+              const width = (seg.people.length / plan.slotsPerRow) * 100;
+              return (
+                <Box
+                  key={seg.label}
+                  sx={{
+                    position: "absolute",
+                    left: `${left}%`,
+                    width: `${width}%`,
+                    borderLeft: seg.start > 0 ? "1px solid" : undefined,
+                    borderColor: "divider",
+                    pl: 0.5,
+                    fontSize: "11.5px",
+                    fontWeight: 600,
+                    color: "text.secondary",
+                    whiteSpace: "nowrap",
+                    overflow: "hidden",
+                  }}
+                >
+                  {/* Too narrow to hold a label without spilling over. */}
+                  {width > 6
+                    ? seg.continued
+                      ? seg.label
+                      : `${seg.label} — ${seg.people.length.toLocaleString()} people`
+                    : ""}
+                </Box>
+              );
+            })}
+          </Box>
+          <div
+            data-row={i}
+            style={{ height: ROW_HEIGHT }}
+            ref={(el) => void (hostRefs.current[i] = el)}
+          />
+          <Typography
+            variant="caption"
+            sx={{ color: "text.secondary", pl: "62px", display: "block" }}
+          >
+            {(row.offset + 1).toLocaleString()}–
+            {(row.offset + row.filled).toLocaleString()} of{" "}
+            {plan.totalPeople.toLocaleString()}, sorted by salary within each
+            duty
+          </Typography>
+        </Box>
+      ))}
+    </Box>
+  );
+}

--- a/app/finance/salaries/page.tsx
+++ b/app/finance/salaries/page.tsx
@@ -1,0 +1,12 @@
+import { Metadata } from "next";
+import SalariesPage from "./SalariesPage";
+
+export const metadata: Metadata = {
+  title: "Salaries Dashboard for Washington State Schools",
+  description:
+    "Every S-275 total final salary for a district and year, one column per person, grouped by duty title.",
+};
+
+export default async function Page() {
+  return <SalariesPage />;
+}

--- a/app/finance/salaries/rowPlan.test.ts
+++ b/app/finance/salaries/rowPlan.test.ts
@@ -1,0 +1,133 @@
+import { groupByDuty, planRows } from "./rowPlan";
+
+import type { Person } from "./rowPlan";
+
+function people(duty: string, salaries: number[], fte = 1): Person[] {
+  return salaries.map((salary) => ({ duty, salary, fte }));
+}
+
+describe("groupByDuty", () => {
+  it("orders duties by total payroll, not headcount", () => {
+    const rows = [
+      ...people("Aide", [10, 10, 10, 10]), // 4 people, $40
+      ...people("Teacher", [50, 50]), // 2 people, $100
+    ];
+    expect([...groupByDuty(rows).keys()]).toEqual(["Teacher", "Aide"]);
+  });
+
+  it("orders people within a duty by salary descending", () => {
+    const rows = people("Teacher", [30, 90, 60]);
+    expect(
+      groupByDuty(rows)
+        .get("Teacher")
+        ?.map((p) => p.salary),
+    ).toEqual([90, 60, 30]);
+  });
+
+  it("breaks payroll ties by name so the layout is stable", () => {
+    const rows = [...people("Zeta", [10]), ...people("Alpha", [10])];
+    expect([...groupByDuty(rows).keys()]).toEqual(["Alpha", "Zeta"]);
+  });
+
+  it("does not mutate the caller's array", () => {
+    const rows = people("Teacher", [30, 90]);
+    const before = rows.map((p) => p.salary);
+    groupByDuty(rows);
+    expect(rows.map((p) => p.salary)).toEqual(before);
+  });
+});
+
+describe("planRows", () => {
+  it("keeps a duty that fits on one row in one segment", () => {
+    const plan = planRows(people("Teacher", [5, 4, 3]), 10);
+    expect(plan.rows).toHaveLength(1);
+    expect(plan.rows[0].segments).toHaveLength(1);
+    expect(plan.rows[0].segments[0].continued).toBe(false);
+    expect(plan.rows[0].filled).toBe(3);
+  });
+
+  it("wraps an oversized duty and labels the continuations", () => {
+    const plan = planRows(people("Teacher", [9, 8, 7, 6, 5]), 2);
+    expect(plan.rows).toHaveLength(3);
+    expect(plan.rows.map((r) => r.segments[0].label)).toEqual([
+      "Teacher",
+      "Teacher Cont'd (1)",
+      "Teacher Cont'd (2)",
+    ]);
+    expect(plan.rows.map((r) => r.filled)).toEqual([2, 2, 1]);
+  });
+
+  it("packs several small duties onto one row", () => {
+    const plan = planRows(
+      [...people("Big", [10, 10]), ...people("Small", [1, 1])],
+      10,
+    );
+    expect(plan.rows).toHaveLength(1);
+    expect(plan.rows[0].segments.map((s) => s.duty)).toEqual(["Big", "Small"]);
+    // Second segment starts where the first left off, so rows share a scale.
+    expect(plan.rows[0].segments.map((s) => s.start)).toEqual([0, 2]);
+  });
+
+  it("splits a duty across the row boundary rather than leaving a gap", () => {
+    const plan = planRows(
+      [...people("Big", [10, 10, 10]), ...people("Small", [1, 1, 1])],
+      4,
+    );
+    expect(plan.rows).toHaveLength(2);
+    expect(
+      plan.rows[0].segments.map((s) => [s.label, s.people.length]),
+    ).toEqual([
+      ["Big", 3],
+      ["Small", 1],
+    ]);
+    expect(
+      plan.rows[1].segments.map((s) => [s.label, s.people.length]),
+    ).toEqual([["Small Cont'd (1)", 2]]);
+  });
+
+  it("never overfills a row and loses nobody", () => {
+    const rows = [
+      ...people(
+        "A",
+        Array.from({ length: 37 }, (_, i) => 100 - i),
+      ),
+      ...people(
+        "B",
+        Array.from({ length: 11 }, (_, i) => 50 - i),
+      ),
+      ...people("C", [7]),
+    ];
+    const plan = planRows(rows, 8);
+    for (const row of plan.rows) {
+      expect(row.filled).toBeLessThanOrEqual(8);
+      const counted = row.segments.reduce((n, s) => n + s.people.length, 0);
+      expect(counted).toBe(row.filled);
+    }
+    const placed = plan.rows.reduce((n, r) => n + r.filled, 0);
+    expect(placed).toBe(rows.length);
+    expect(plan.totalPeople).toBe(rows.length);
+  });
+
+  it("numbers each row's offset across the whole roster", () => {
+    const plan = planRows(people("A", [9, 8, 7, 6, 5]), 2);
+    expect(plan.rows.map((r) => r.offset)).toEqual([0, 2, 4]);
+  });
+
+  it("reports the tallest salary for a shared y-axis", () => {
+    const plan = planRows([...people("A", [10, 400]), ...people("B", [7])], 2);
+    expect(plan.maxSalary).toBe(400);
+  });
+
+  it("handles an empty roster", () => {
+    const plan = planRows([], 10);
+    expect(plan.rows).toEqual([]);
+    expect(plan.maxSalary).toBe(0);
+    expect(plan.totalPeople).toBe(0);
+  });
+
+  it("rejects a nonsense row width instead of looping forever", () => {
+    expect(() => planRows(people("A", [1]), 0)).toThrow(/slotsPerRow/);
+    expect(() => planRows(people("A", [1]), -3)).toThrow(/slotsPerRow/);
+    expect(() => planRows(people("A", [1]), NaN)).toThrow(/slotsPerRow/);
+  });
+});

--- a/app/finance/salaries/rowPlan.ts
+++ b/app/finance/salaries/rowPlan.ts
@@ -1,0 +1,137 @@
+// Row planning for the salary skyline.
+//
+// One column per employee, ordered by duty title, is far too wide to read on a
+// single axis -- SPS 2024-25 is 7,156 people. The chart instead wraps into
+// rows of a fixed number of people, the way a paragraph wraps into lines, and
+// a duty title that does not fit in what is left of a row continues onto the
+// next one under a "Cont'd" label.
+//
+// Every row is planned to the same slot count so the rows share a horizontal
+// scale: a column 40% across row 3 sits above a column 40% across row 1. The
+// final row is left short rather than stretched, for the same reason.
+
+export type Person = {
+  duty: string;
+  salary: number;
+  fte: number;
+};
+
+/** A run of one duty title's people inside a single row. */
+export type Segment = {
+  duty: string;
+  /** Display label; the duty title, or "<duty> Cont'd (n)" on later rows. */
+  label: string;
+  /** True when this segment continues a duty title from an earlier row. */
+  continued: boolean;
+  /** Slot index of this segment's first person within its row. */
+  start: number;
+  people: Person[];
+};
+
+export type Row = {
+  segments: Segment[];
+  /** People in this row; <= slotsPerRow, and short on the final row. */
+  filled: number;
+  /** Index of this row's first person across the whole roster, for captions. */
+  offset: number;
+};
+
+export type Plan = {
+  rows: Row[];
+  slotsPerRow: number;
+  /** Tallest salary anywhere, so every row can share one y-axis. */
+  maxSalary: number;
+  totalPeople: number;
+};
+
+/**
+ * Group people by duty title, biggest payroll first, each group's people
+ * ordered by salary descending -- the shape the skyline is read in.
+ */
+export function groupByDuty(people: Person[]): Map<string, Person[]> {
+  const byDuty = new Map<string, Person[]>();
+  for (const p of people) {
+    const bucket = byDuty.get(p.duty);
+    if (bucket) {
+      bucket.push(p);
+    } else {
+      byDuty.set(p.duty, [p]);
+    }
+  }
+
+  const payroll = (rows: Person[]) =>
+    rows.reduce((sum, p) => sum + p.salary, 0);
+  const ordered = [...byDuty.entries()].sort((a, b) => {
+    const diff = payroll(b[1]) - payroll(a[1]);
+    // Ties broken by name so the layout is stable across reloads.
+    return diff !== 0 ? diff : a[0].localeCompare(b[0]);
+  });
+
+  return new Map(
+    ordered.map(([duty, rows]) => [
+      duty,
+      [...rows].sort((a, b) => b.salary - a.salary),
+    ]),
+  );
+}
+
+/**
+ * Lay people out into rows of `slotsPerRow` columns, splitting a duty title
+ * across rows when it does not fit in what is left of the current one.
+ */
+export function planRows(people: Person[], slotsPerRow: number): Plan {
+  if (!Number.isFinite(slotsPerRow) || slotsPerRow < 1) {
+    throw new Error(`slotsPerRow must be >= 1, got ${slotsPerRow}`);
+  }
+
+  const byDuty = groupByDuty(people);
+  const rows: Row[] = [];
+  let row: Segment[] = [];
+  let filled = 0;
+  let placed = 0;
+
+  const closeRow = () => {
+    if (row.length > 0) {
+      rows.push({ segments: row, filled, offset: placed });
+      placed += filled;
+      row = [];
+      filled = 0;
+    }
+  };
+
+  for (const [duty, members] of byDuty) {
+    // `part` counts how many rows of this duty are already placed, so the
+    // continuation labels number from 1 rather than restarting per row.
+    let part = 0;
+    let offset = 0;
+    while (offset < members.length) {
+      const room = slotsPerRow - filled;
+      if (room === 0) {
+        closeRow();
+        continue;
+      }
+      const take = Math.min(room, members.length - offset);
+      row.push({
+        duty,
+        label: part === 0 ? duty : `${duty} Cont'd (${part})`,
+        continued: part > 0,
+        start: filled,
+        people: members.slice(offset, offset + take),
+      });
+      offset += take;
+      filled += take;
+      part += 1;
+      if (filled === slotsPerRow) {
+        closeRow();
+      }
+    }
+  }
+  closeRow();
+
+  return {
+    rows,
+    slotsPerRow,
+    maxSalary: people.reduce((max, p) => Math.max(max, p.salary), 0),
+    totalPeople: people.length,
+  };
+}

--- a/functions/src/finance.ts
+++ b/functions/src/finance.ts
@@ -299,7 +299,7 @@ function getS275Salaries(ccddd) {
   )
   SELECT
     r.school_year,
-    CAST(SPLIT(r.school_year, '-')[1] as int) class_of,
+    r.class_of,
     p.dr duty_root_code,
     d_dr.duty_name duty_root,
     pre.total_final_salary,

--- a/functions/src/finance.ts
+++ b/functions/src/finance.ts
@@ -252,6 +252,74 @@ function getS275Summary(ccddd) {
   `;
 }
 
+// One row per employee per S-275 final report: their total_final_salary, their
+// total FTE, and the duty root they are counted under. This is the per-person
+// grain the Salaries dashboard draws -- getS275Summary() above answers "what
+// does this duty cost in total", which cannot be un-summed back into people.
+//
+// Three things are easy to get wrong here, all of them multi-counting:
+//   * total_final_salary lives on the *employee* (private_report_employee), not
+//     the assignment. Joining it per assignment repeats one person's whole
+//     salary once per assignment they hold.
+//   * fte_in_assignment is the only additive FTE column. The certificated /
+//     classified columns on assignment_fte are per-employee markers and
+//     over-count by roughly 5x if summed.
+//   * a person can hold assignments under several duty roots. They are counted
+//     once, under the duty of their major assignment, matching how the printed
+//     apportionment reports attribute staff.
+// Verified against the SEA-critique extract: SPS 2024-25 comes back 7,156
+// people / $684.0M, the same as tools/sea_chart_critique/staff_2425.csv.
+function getS275Salaries(ccddd) {
+  return `
+  WITH per_duty AS (
+    SELECT
+      a.report_employee_id emp,
+      a.duty_root_code dr,
+      SUM(a.fte_in_assignment) fte,
+      COUNTIF(a.is_major) nmaj,
+      SUM(COALESCE(pa.assignment_salary, 0)) sal
+    FROM
+      sps-btn-data.safs_s275.assignment a
+      JOIN sps-btn-data.safs_s275.report r ON (a.report_id = r.report_id)
+      LEFT JOIN sps-btn-data.safs_s275.private_assignment pa
+        ON (pa.assignment_id = a.assignment_id)
+    WHERE
+      r.report_type = 'final' AND
+      r.ccddd = ${ccddd}
+    GROUP BY emp, dr
+  ),
+  pick AS (
+    SELECT emp, dr,
+      ROW_NUMBER() OVER (
+        PARTITION BY emp ORDER BY nmaj DESC, fte DESC, sal DESC, dr) rn
+    FROM per_duty
+  ),
+  tot AS (
+    SELECT emp, SUM(fte) fte FROM per_duty GROUP BY emp
+  )
+  SELECT
+    r.school_year,
+    CAST(SPLIT(r.school_year, '-')[1] as int) class_of,
+    p.dr duty_root_code,
+    d_dr.duty_name duty_root,
+    pre.total_final_salary,
+    t.fte
+  FROM
+    pick p
+    JOIN tot t ON (t.emp = p.emp)
+    JOIN sps-btn-data.safs_s275.report_employee re
+      ON (re.report_employee_id = p.emp)
+    JOIN sps-btn-data.safs_s275.report r ON (r.report_id = re.report_id)
+    JOIN sps-btn-data.safs_s275.private_report_employee pre
+      ON (pre.report_employee_id = p.emp)
+    LEFT JOIN sps-btn-data.safs_domains.d_duty_root d_dr
+      ON (d_dr.duty_root = p.dr)
+  WHERE
+    p.rn = 1 AND
+    pre.total_final_salary IS NOT NULL
+  `;
+}
+
 // Budgeted (F-195 salary exhibit) FTE. This is the district's BUDGET filing, so
 // it has NO school breakdown -- FTE is only reported by program / activity /
 // duty. We roll General Fund `detail` rows (the `activity_total` / `program_total`
@@ -331,6 +399,8 @@ function getQueryForDataset(ccddd, dataset) {
       return getActualsItems(ccddd);
     } else if (dataset === 's275_summary') {
       return getS275Summary(ccddd);
+    } else if (dataset === 's275_salaries') {
+      return getS275Salaries(ccddd);
     } else if (dataset === 'budgeted_fte') {
       return getBudgetedFte(ccddd);
     } else if (dataset === 'budgetary_comparison') {

--- a/functions/src/finance.ts
+++ b/functions/src/finance.ts
@@ -11,6 +11,13 @@ import {
 
 const bigqueryClient = new BigQuery();
 
+// Each dataset below is one BigQuery query, exported to a cached AVRO the
+// client fetches directly. Note that makeCachePaths() keys the cache on a
+// sha256 of the query *text*: editing a query here, even by a character,
+// moves its cache path, so the next request re-exports it and the objects
+// under the old hash are orphaned in the bucket. Worth a sweep of
+// gs://sps-by-the-numbers-public/cache/scratch/ after changing one.
+
 function getEnrollment(ccddd) {
   return `
   SELECT
@@ -210,7 +217,7 @@ function getS275Summary(ccddd) {
   return `
   SELECT
     r.school_year,
-    CAST(SPLIT(r.school_year, '-')[1] as int) class_of,
+    r.class_of,
     a.school_code,
     d_s.school,
     a.program_code,


### PR DESCRIPTION
A new **Salaries** tab in the finance sub-nav. Pick a district and year and every S-275 `total_final_salary` is drawn as one column per person, grouped by the duty title of their major assignment, sorted by salary within each duty, wrapping at 1,500 people per row. Every row shares one salary scale and one slot count, so heights and horizontal positions mean the same thing from row to row.

## Needs a deploy before it does anything

Per-employee salary reaches the browser nowhere today — the public S-275 AVROs carry no salary column at all, and `getS275Summary()` only escapes BigQuery already grouped by school / program / activity / duty. This adds an `s275_salaries` dataset at the per-employee grain.

**It needs `cd functions && npm run deploy`**, and that deploy publishes one row per employee (duty, FTE, salary — no school or program, to limit re-identification) to a public bucket. That is the main thing to weigh in this review; the same numbers are already public in the SEA critique's img3, but it is a data-publication call, not a code one. Until it is deployed the page shows an explanatory notice rather than breaking.

## Getting the query right

Three things multi-count here, all called out in data-tools' own SQL comments:

- `total_final_salary` lives on the **employee**, not the assignment — joining it per assignment repeats a whole salary once per assignment that person holds
- `fte_in_assignment` is the only additive FTE column; the certificated / classified columns on `assignment_fte` are per-employee markers and over-count by ~5x
- someone holding assignments under several duty roots is counted once, under the duty of their major assignment

**Validated against BigQuery:** SPS 2024-25 returns **7,156 people / $684.0M**, matching `tools/sea_chart_critique/staff_2425.csv` exactly.

## Two implementation notes worth a look

**Stepped areas, not a column series.** At ~1,500 people across ~1,400px a column is under a pixel wide, so the two are pixel-identical — but a column series emits one SVG path per person (7,156 for SPS 2024-25), which froze the renderer outright. Each duty is now one stepped area path (114 total) while keeping a point per person, so tooltips still resolve to an individual and carry the raw salary and FTE that the height alone cannot show.

**A latent styling conflict, possibly affecting other charts.** The app loads Highcharts' styled-mode CSS while charts run in normal mode, so `.highcharts-color-N { fill: var(--highcharts-color-N) }` silently overrides `fill` attributes. Per-point colors were ignored, and a plot band set to `transparent` computed to black. Worked around here by setting both `color` and `colorIndex` and moving duty labels to positioned HTML — but other charts on the site may be picking up theme colors rather than the ones their code asks for.

## Also in here: a `class_of` cleanup

`safs_s275.report` already carries `class_of` as an `INTEGER` column, so both this PR's new query and the existing `getS275Summary` were recomputing it with `CAST(SPLIT(school_year, '-')[1] AS INT64)`. Both now read `r.class_of`.

Safe because across all 3,853 reports `class_of` is never NULL and never disagrees with the split, and running both forms of `getS275Summary` side by side returns **45,670 rows each with an empty `EXCEPT DISTINCT` in both directions** — identical row for row.

One consequence: `makeCachePaths()` keys the cache on a `sha256` of the query **text**, so editing a query moves that dataset's cache path. `s275_summary` has 2 cached districts today; they re-export on next request and the objects under the old hash can be swept from `gs://sps-by-the-numbers-public/cache/scratch/`. Nothing in `finance.ts` said this, so there's now a short note above the query functions.

## Checks

- `tsc` clean, site and `functions/`
- **206 tests pass**, including 13 new ones covering the row wrapping (continuation labels, splitting a duty across a row boundary, never overfilling or losing anyone, rejecting a nonsense row width)
- build compiles, prerenders 35 pages
- lint clean on changed files
- verified in a production build: year selector, district selector, and tooltips (`$113,829 · Elementary Homeroom Teacher · 1.00 FTE`)

Chart verification used a local-only copy of the query results rather than the emulator, since the emulator would have written per-employee salary to the public cache bucket before you had decided on it.

## Not included

Image 3's red state-funding-rate line and shaded funded-units block. That is the critique overlay rather than the payroll chart, it needs the 1191F apportionment rates, and on a headcount axis the funded-units mark lands in the wrong place — the 31% error the reference's own docstring warns about. Happy to add it behind an FTE-axis toggle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
