### PR TITLE
Use report.class_of instead of recomputing it from school_year

### DIFF
--- a/functions/src/finance.ts
+++ b/functions/src/finance.ts
@@ -11,6 +11,13 @@ import {
 
 const bigqueryClient = new BigQuery();
 
+// Each dataset below is one BigQuery query, exported to a cached AVRO the
+// client fetches directly. Note that makeCachePaths() keys the cache on a
+// sha256 of the query *text*: editing a query here, even by a character,
+// moves its cache path, so the next request re-exports it and the objects
+// under the old hash are orphaned in the bucket. Worth a sweep of
+// gs://sps-by-the-numbers-public/cache/scratch/ after changing one.
+
 function getEnrollment(ccddd) {
   return `
   SELECT
@@ -210,7 +217,7 @@ function getS275Summary(ccddd) {
   return `
   SELECT
     r.school_year,
-    CAST(SPLIT(r.school_year, '-')[1] as int) class_of,
+    r.class_of,
     a.school_code,
     d_s.school,
     a.program_code,


### PR DESCRIPTION
Follow-up to the review comment on #30.

`safs_s275.report` already carries `class_of` as an `INTEGER` column, so `getS275Summary` was recomputing a value the join already had:

```sql
-CAST(SPLIT(r.school_year, '-')[1] as int) class_of,
+r.class_of,
```

## Why it's safe

Across all 3,853 reports, `class_of` is never NULL and never disagrees with the split:

| reports | null_class_of | disagree |
|---|---|---|
| 3853 | 0 | 0 |

And running both forms of the full query side by side returns **45,670 rows each**, with an empty `EXCEPT DISTINCT` in **both** directions — so the output is identical row for row, not merely the same shape.

## One consequence worth knowing

`makeCachePaths()` keys the cache on a `sha256` of the query **text**, so editing any query in this file moves that dataset's cache path. The next request re-exports it, and the objects under the old hash are orphaned in the bucket. That applies here: `s275_summary` has 2 cached districts today, which will re-export on next request, and the old objects can be swept from `gs://sps-by-the-numbers-public/cache/scratch/`.

Nothing in `finance.ts` said this, so I added a short note above the query functions. That's the only other change in the diff.

## Relationship to #30

Both touch `functions/src/finance.ts`. I test-merged this branch into `salaries-dashboard` locally and it auto-merges cleanly (different regions of the file), so they can land in either order.

## Checks

`tsc` clean for both the site and `functions/`, `functions` bundle builds, 193 tests pass, and lint on `finance.ts` is unchanged at its 25 pre-existing errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)