### PR TITLE
Salaries: fix the doubled nav, and add a settings drawer

### DIFF
--- a/DISTRICT_DATA_PLAN.md
+++ b/DISTRICT_DATA_PLAN.md
@@ -1,0 +1,176 @@
+# Plan: load only the datasets a dashboard needs
+
+`EnsureDistrictData` blocks every finance dashboard on all eleven district
+datasets. This plan makes the blocking load the subset a dashboard actually
+reads, without giving up the cache that makes tab-to-tab switching instant.
+
+## What it costs today
+
+`DistrictData.loadFromGcs` fetches eleven datasets in one `Promise.all` and the
+constructor takes all eleven frames. `EnsureDistrictData` renders `Loading…`
+until `ccddd in districtDataMap`, so nothing paints until the slowest finishes.
+
+Measured over the wire for Seattle (17001), compressed AVRO:
+
+| dataset | bytes |
+| --- | ---: |
+| gf_expenditures | 6,133,051 |
+| assessment | 5,224,948 |
+| sqss | 4,316,181 |
+| s275_summary | 1,831,418 |
+| actuals_items | 255,739 |
+| enrollment | 234,520 |
+| budget_items | 62,996 |
+| gf_revenues | 28,720 |
+| budgeted_fte | 23,439 |
+| fundedEnrollment | 12,674 |
+| budgetary_comparison | 5,509 |
+| **total** | **~18.1 MB** |
+
+Three datasets are 83% of it. What each dashboard needs, tracing every
+`DistrictData` accessor through to the frames it touches:
+
+| dashboard | needs | unused today |
+| --- | --- | ---: |
+| Enrollment | enrollment | ~17.9 MB |
+| Assessments | assessment | ~12.9 MB |
+| Vitals / Revenues / Correlations | budget_items, budgeted_fte, s275_summary, gf_expenditure, gf_revenue, actuals_items, fundedEnrollment | ~9.5 MB |
+| Money Flows | enrollment, gf_expenditure, gf_revenue | ~11.9 MB |
+| Staffing | + budget_items, budgeted_fte, s275_summary | ~9.5 MB |
+
+Nothing outside Assessments reads `assessment`; nothing reads `sqss` at all
+through `DistrictData`. That is 9.5 MB every dashboard pays and no dashboard
+except Assessments spends.
+
+## What must not regress
+
+1. **Tab-to-tab speed.** `DistrictDataProvider` sits in `app/finance/layout.tsx`,
+   so it stays mounted across finance route changes and `districtDataMap`
+   survives them. Any refactor has to keep a cache at that level, or switching
+   tabs starts refetching.
+2. **Multi-district comparison.** `allSettings` can hold several districts; the
+   cache is keyed by `ccddd` and must stay that way.
+3. **Graceful degrade.** `budgeted_fte` and `budgetary_comparison` fall back to
+   empty, correctly-shaped frames when the fetch fails, so one missing dataset
+   cannot break every dashboard. That is per-dataset behavior and must survive.
+4. **Settings-driven reloads.** Changing district in the drawer re-runs
+   `loadCcddd`; the in-flight dedupe in `previouslyLoadedCcddds` must not
+   regress into double fetches.
+
+## The shape of the change
+
+Three pieces, each independently shippable.
+
+### 1. A dataset-level cache, keyed `(ccddd, dataset)`
+
+Replace `districtDataMap: {ccddd -> DistrictData}` with a store of
+**promises**, not values:
+
+```ts
+Map<`${Ccddd}:${DatasetName}`, Promise<ColumnTable>>
+```
+
+Promise-keyed matters: two dashboards asking for `gf_expenditures` while it is
+in flight share one request, and an already-resolved entry is effectively free.
+This subsumes what `previouslyLoadedCcddds` does today, so that set goes away.
+
+Per-dataset fallbacks (the empty frames) move next to the fetch, so each entry
+resolves to a usable frame either way.
+
+### 2. `DistrictData` becomes a view, not an owner
+
+Today the constructor takes eleven positional frames — adding or removing one
+touches every call site. Change it to take a partial bundle:
+
+```ts
+type DatasetBundle = Partial<Record<DatasetName, ColumnTable>>;
+new DistrictData(bundle)
+```
+
+Accessors read from the bundle and **throw a named error** when a dataset was
+not requested:
+
+> `DistrictData.expenditures() needs "gf_expenditures", which this dashboard did not declare.`
+
+That turns a wrong declaration into an immediate, self-explaining failure
+instead of a confusing empty chart. Worth keeping loud in production too — an
+empty chart is a worse bug than a clear crash.
+
+### 3. Dashboards declare what they need
+
+`EnsureDistrictData` gains a `datasets: DatasetName[]` prop and awaits only
+those. Dashboards should not hand-list them, because most reach the data
+indirectly: only Flow touches `DistrictData` directly, and everything else goes
+through **`ChartableMetrics`** or **`ChartableVitals`**. Those two modules are
+the only indirect callers, which is what makes this tractable.
+
+So export the requirement from where the dependency lives:
+
+```ts
+// utilities/ChartableVitals.ts
+export const VITALS_DATASETS = [
+  "budget_items", "budgeted_fte", "s275_summary",
+  "gf_expenditures", "gf_revenues", "actuals_items", "fundedEnrollment",
+] as const;
+```
+
+and let a dashboard compose:
+
+```ts
+datasets={[...VITALS_DATASETS, "assessment"]}
+```
+
+If a helper later reads a new frame, the constant moves with it and every
+dashboard using that helper picks it up — the declaration cannot drift from the
+code that depends on it.
+
+### 4. Prefetch the rest when idle
+
+Declaring a subset makes first paint cheap but would make the *first* switch to
+a heavier tab slower than today. So after the blocking set resolves, kick off
+the remaining datasets for the current district at idle
+(`requestIdleCallback`, `void`-ed, never awaited). They land in the same cache,
+so the next tab finds them warm.
+
+Net effect: first paint waits on what this dashboard needs; moving between tabs
+usually waits on nothing.
+
+## Suggested order
+
+1. **Cache + bundle, no behavior change.** Introduce the promise cache and the
+   `DatasetBundle` constructor, with `EnsureDistrictData` still requesting all
+   eleven. Nothing gets faster; everything keeps working. Ship it.
+2. **Add `datasets` and declare per dashboard.** Start with Enrollment and
+   Assessments — the biggest wins and the simplest dependency sets — then the
+   `ChartableVitals` group. Verify each tab still renders before moving on.
+3. **Add idle prefetch.** Measure tab-switch time before and after.
+4. **Drop `sqss` from `DistrictData` entirely** if the audit holds that nothing
+   reads it (4.3 MB). Check the SQSS page first — it may fetch separately.
+
+Steps 1 and 2 are independently valuable; if step 3 proves unnecessary, skip it.
+
+## Risks
+
+- **A missed indirect reader.** The audit found two chokepoints, but it was a
+  static scan of `.method(` calls. A dynamic or re-exported call would be
+  missed. The throwing accessor in §2 is the mitigation: it fails loudly at the
+  first wrong declaration rather than silently drawing nothing.
+- **Comparison mode.** With several districts in `allSettings`, the declared set
+  is fetched per district. Fine, but the loading gate has to check every
+  (ccddd, dataset) pair, not just every ccddd.
+- **Empty-frame fallbacks becoming load-bearing.** Once datasets are optional,
+  it gets tempting to let a missing declaration fall back to an empty frame.
+  Do not — that is the silent-wrong-chart failure mode. Fallbacks stay only for
+  datasets that genuinely may not exist for a district.
+- **`sqss` may have a non-`DistrictData` reader.** Confirm before removing.
+
+## Worth deciding first
+
+- Should the throwing accessor throw in production, or warn and return empty?
+  (Recommendation: throw. A blank chart with no explanation is the bug we are
+  trying to avoid creating.)
+- Is comparison mode across districts still used? If not, the cache key
+  simplifies and the loading gate gets easier.
+- Salaries currently bypasses this system entirely and fetches `s275_salaries`
+  itself. Once `datasets` exists it could join, using the same cache — worth
+  doing for consistency, though it gains little on its own.

--- a/app/PrimaryNav.tsx
+++ b/app/PrimaryNav.tsx
@@ -71,6 +71,7 @@ const FINANCE_NAV_CONFIGS: Array<NavConfig> = [
   { name: "Revenues", isAppPath: true, pathPrefix: "revenues" },
   { name: "Detailed Actuals", isAppPath: true, pathPrefix: "detailedactuals" },
   { name: "Staffing", isAppPath: true, pathPrefix: "staffing" },
+  { name: "Salaries", isAppPath: true, pathPrefix: "salaries" },
   { name: "Enrollment", isAppPath: true, pathPrefix: "enrollment" },
   { name: "Assessments", isAppPath: true, pathPrefix: "assessments" },
   { name: "Correlations", isAppPath: true, pathPrefix: "correlations" },

--- a/app/finance/_providers/DistrictDataProvider.tsx
+++ b/app/finance/_providers/DistrictDataProvider.tsx
@@ -1,13 +1,26 @@
 "use client";
 
-import { createContext, useContext, useState, useEffect, useMemo } from "react";
+import {
+  createContext,
+  useContext,
+  useState,
+  useEffect,
+  useMemo,
+  useRef,
+} from "react";
+import { prefetchRemaining } from "utilities/client/DistrictDatasets";
+
+import type { DatasetName } from "utilities/client/DistrictDatasets";
 import { deserializeDatasetSettings } from "app/finance/_settings/common_settings";
 import { deserializeContextSettings } from "app/finance/_settings/common_context_settings";
-import { useSearchParams } from 'next/navigation';
+import { useSearchParams } from "next/navigation";
 import DistrictData from "utilities/DistrictData";
 import Loading from "components/Loading";
 
-import type { BaseSettings, SettingsConfigGenerators } from "app/finance/_settings/base_settings";
+import type {
+  BaseSettings,
+  SettingsConfigGenerators,
+} from "app/finance/_settings/base_settings";
 import type { DatasetSettings } from "app/finance/_settings/dataset_settings";
 import type { ReactNode, ComponentType } from "react";
 
@@ -16,7 +29,7 @@ export type DistrictDataMap = Map<Ccddd, DistrictData>;
 
 type DistrictDataContextType = {
   districtDataMap: DistrictDataMap;
-  loadCcddd: (ccddd: Ccddd) => void;
+  loadCcddd: (ccddd: Ccddd, datasets: readonly DatasetName[]) => void;
 };
 
 type DistrictDataProviderParams = {
@@ -35,14 +48,22 @@ export type DistrictDataContentProps<
 type EnsureDistrictDataProps<
   SettingsType extends DatasetSettings,
   ContextSettingsType extends BaseSettings,
->  = {
+> = {
   defaultAllSettings: Array<SettingsType>;
   allSettingsConfigGenerators: SettingsConfigGenerators;
 
   defaultContextSettings: ContextSettingsType;
   contextSettingsConfigGenerators?: SettingsConfigGenerators;
 
-  ContentComponent: ComponentType<DistrictDataContentProps<SettingsType, ContextSettingsType>>;
+  ContentComponent: ComponentType<
+    DistrictDataContentProps<SettingsType, ContextSettingsType>
+  >;
+
+  // The datasets this dashboard reads. Compose these from the DATASETS
+  // constants exported by the helpers a dashboard uses (ChartableMetrics,
+  // ChartableVitals) rather than hand-listing them, so the declaration cannot
+  // drift from the code that depends on it.
+  datasets: readonly DatasetName[];
 };
 
 // Pattern from https://stackoverflow.com/a/74174425
@@ -71,33 +92,41 @@ export function EnsureDistrictData<
   contextSettingsConfigGenerators,
 
   ContentComponent,
+  datasets,
 }: EnsureDistrictDataProps<SettingsType, ContextSettingsType>) {
   // Make one up for places that don't use it.
   const { districtDataMap, loadCcddd } = useDistrictData();
   const searchParams = useSearchParams();
 
   const allSettings = deserializeDatasetSettings(
-    searchParams.getAll('d'),
+    searchParams.getAll("d"),
     defaultAllSettings,
-    allSettingsConfigGenerators
+    allSettingsConfigGenerators,
   );
 
   const contextSettings = deserializeContextSettings(
-    searchParams.getAll('c'),
+    searchParams.getAll("c"),
     defaultContextSettings,
-    contextSettingsConfigGenerators ?? []
+    contextSettingsConfigGenerators ?? [],
   );
 
   // The memoization happens in loadCcddd. The rest of the useEffect dependency
   // is largely nonsensical.
+  // datasets is a module-level constant array per dashboard, but join it so a
+  // caller passing a fresh literal each render does not re-fire the effect.
+  const datasetKey = datasets.join(",");
   useEffect(() => {
     for (const settings of allSettings) {
-      loadCcddd(settings.ccddd);
+      loadCcddd(settings.ccddd, datasetKey.split(",") as DatasetName[]);
     }
-  }, [allSettings, loadCcddd]);
+  }, [allSettings, loadCcddd, datasetKey]);
 
   for (const settings of allSettings) {
-    if (!(settings.ccddd in districtDataMap)) {
+    const districtData = districtDataMap[settings.ccddd];
+    // Both halves matter: the district may not be loaded at all, or it may be
+    // loaded from a narrower tab's dataset list and be missing a frame this
+    // dashboard declared.
+    if (!districtData || !districtData.hasAll(datasets)) {
       return <Loading text={`Loading distrct data for ${settings.ccddd}...`} />;
     }
   }
@@ -111,27 +140,48 @@ export function EnsureDistrictData<
   );
 }
 
-export default function DistrictDataProvider({ children }: DistrictDataProviderParams) {
-  // Use previouslyLoadedCcddds to keep track of requests to prevent double-loading the dataset.
-  const [previouslyLoadedCcddds, setPreviouslyLoadedCcddds] = useState<
-    Set<Ccddd>
-  >(new Set<Ccddd>());
+export default function DistrictDataProvider({
+  children,
+}: DistrictDataProviderParams) {
+  // districtDataMap holds a DistrictData per district built from whatever
+  // datasets have been requested so far. The underlying frames are cached in
+  // DistrictDatasets, so rebuilding this for a wider dataset set re-uses
+  // everything already fetched -- switching tabs costs only the datasets the
+  // new tab adds, and usually nothing at all once the idle prefetch has run.
   const [districtDataMap, setDistrictDataMap] = useState<DistrictDataMap>(
     {} as DistrictDataMap,
   );
+  // What we have actually loaded per district, so a tab needing a superset
+  // triggers a rebuild and a tab needing a subset does not.
+  const loadedRef = useRef<Map<Ccddd, Set<DatasetName>>>(new Map());
 
   const value = useMemo(() => {
-    // Used to signal a new data fetch.
-    const loadCcddd = async (ccddd: Ccddd) => {
-      if (!previouslyLoadedCcddds.has(ccddd)) {
-        setPreviouslyLoadedCcddds(new Set(previouslyLoadedCcddds).add(ccddd));
-        const newDistrictDataMap = Object.assign({}, districtDataMap);
-        newDistrictDataMap[ccddd] = await DistrictData.loadFromGcs(ccddd);
-        setDistrictDataMap(newDistrictDataMap);
+    const loadCcddd = async (
+      ccddd: Ccddd,
+      datasets: readonly DatasetName[],
+    ) => {
+      const have = loadedRef.current.get(ccddd) ?? new Set<DatasetName>();
+      const missing = datasets.filter((d) => !have.has(d));
+      if (missing.length === 0) return;
+
+      const wanted = new Set([...have, ...datasets]);
+      // Claim the wider set up front so concurrent callers do not each kick
+      // off their own rebuild; the per-dataset cache dedupes the fetches
+      // regardless, but this keeps the state churn down.
+      loadedRef.current.set(ccddd, wanted);
+
+      try {
+        const districtData = await DistrictData.loadFromGcs(ccddd, [...wanted]);
+        setDistrictDataMap((prev) => ({ ...prev, [ccddd]: districtData }));
+        prefetchRemaining(ccddd, [...wanted]);
+      } catch (err) {
+        // Let a later attempt retry rather than wedging the district.
+        loadedRef.current.set(ccddd, have);
+        throw err;
       }
     };
     return { districtDataMap, loadCcddd };
-  }, [districtDataMap, previouslyLoadedCcddds]);
+  }, [districtDataMap]);
 
   return (
     <DistrictDataContext.Provider value={value}>

--- a/app/finance/_widgets/FinanceSubNav.tsx
+++ b/app/finance/_widgets/FinanceSubNav.tsx
@@ -29,7 +29,6 @@ export default function FinanceSubNav({ sx = [] }: Params) {
         <NavLink href={"/finance/revenues"}>Revenues</NavLink>
         <NavLink href={"/finance/detailedactuals"}>Detailed Actuals</NavLink>
         <NavLink href={"/finance/staffing"}>Staffing</NavLink>
-        <NavLink href={"/finance/salaries"}>Salaries</NavLink>
         <NavLink href={"/finance/correlations"}>Correlations</NavLink>
       </Stack>
     </Toolbar>

--- a/app/finance/_widgets/SettingsLayout.tsx
+++ b/app/finance/_widgets/SettingsLayout.tsx
@@ -339,11 +339,18 @@ export default function SettingsLayout<
           // Default flex-item min-width is auto (= min-content), which
           // would let the dashboard's intrinsic content width (e.g. a
           // wide context band) push this Box past the viewport on
-          // mobile. minWidth: 0 + overflow: hidden caps the Box at the
+          // mobile. minWidth: 0 + overflowX: hidden caps the Box at the
           // available row width and contains any horizontal overflow
           // inside the inner scroll containers.
+          //
+          // The vertical axis has to scroll, though: this Box is 100% of a
+          // 100vh parent, so a page taller than the viewport (the Salaries
+          // skyline is one chart row per ~1,500 people) would otherwise be
+          // clipped with no way to reach the bottom. Scrolling here rather
+          // than on the window keeps the settings drawer pinned.
           minWidth: 0,
-          overflow: "hidden",
+          overflowX: "hidden",
+          overflowY: "auto",
           p: 0,
           width: { sm: `calc(100% - ${drawerWidthPx}px)` },
         }}

--- a/app/finance/assessments/AssessmentPage.tsx
+++ b/app/finance/assessments/AssessmentPage.tsx
@@ -4,7 +4,10 @@ import { DEFAULT_COMMON_FACET_CONTEXT_SETTINGS } from "app/finance/_settings/com
 import { DEFAULT_DATASET_SETTINGS } from "app/finance/_settings/dataset_settings";
 import { DUMMY_BASE_SETTINGS } from "app/finance/_settings/base_settings";
 import { EnsureDistrictData } from "app/finance/_providers/DistrictDataProvider";
-import { makeDefaultDatasetSettings, makeDefaultAssessmentFilterSettings } from "app/finance/_settings/common_settings";
+import {
+  makeDefaultDatasetSettings,
+  makeDefaultAssessmentFilterSettings,
+} from "app/finance/_settings/common_settings";
 import { makeSchoolFilter } from "app/finance/_filteritems/school";
 import { serializeFacet, deserializeFacet } from "./AssessmentDashboard";
 import * as CommonContextSettingsAll from "app/finance/_settings/common_context_settings";
@@ -22,10 +25,11 @@ export type CovidYears = (typeof ALL_COVID_YEARS)[number];
 export const ALL_DISCLOSURE_AVOIDANCE = ["best_guess", "drop"] as const;
 export type DisclosureAvoidance = (typeof ALL_DISCLOSURE_AVOIDANCE)[number];
 
-const DISCLOSURE_AVOIDANCE_SERIALIZE_MAP: Record<DisclosureAvoidance, string> = {
-  best_guess: "0",
-  drop: "1",
-};
+const DISCLOSURE_AVOIDANCE_SERIALIZE_MAP: Record<DisclosureAvoidance, string> =
+  {
+    best_guess: "0",
+    drop: "1",
+  };
 const DISCLOSURE_AVOIDANCE_DESERIALIZE_MAP = Object.fromEntries(
   Object.entries(DISCLOSURE_AVOIDANCE_SERIALIZE_MAP).map(([k, v]) => [v, k]),
 ) as Record<string, DisclosureAvoidance>;
@@ -40,21 +44,24 @@ export function deserializeDisclosureAvoidance(s: string): DisclosureAvoidance {
 
 // Maps a disclosure-avoidance choice to the BigQuery column the chart
 // should source pct_met_standard from.
-export const DISCLOSURE_AVOIDANCE_METRIC: Record<DisclosureAvoidance, string> = {
-  best_guess: "pct_met_standard_withdat",
-  drop: "pct_met_standard_nodat",
-};
+export const DISCLOSURE_AVOIDANCE_METRIC: Record<DisclosureAvoidance, string> =
+  {
+    best_guess: "pct_met_standard_withdat",
+    drop: "pct_met_standard_nodat",
+  };
 
 function makeDisclosureAvoidanceSerializeConfig(context?): SettingsConfig {
   return [
     [
-      "disclosureAvoidance", {
+      "disclosureAvoidance",
+      {
         serializerType: "custom",
         urlVar: "da",
-        serialize: (settings, key) => serializeDisclosureAvoidance(settings[key]),
-          deserialize: (settings, s) => deserializeDisclosureAvoidance(s),
+        serialize: (settings, key) =>
+          serializeDisclosureAvoidance(settings[key]),
+        deserialize: (settings, s) => deserializeDisclosureAvoidance(s),
       },
-    ]
+    ],
   ];
 }
 
@@ -77,19 +84,38 @@ export function deserializeCovidYears(s: string): CovidYears {
 function makeCovidYearsSerializeConfig(context?): SettingsConfig {
   return [
     [
-      "covidYears", {
+      "covidYears",
+      {
         serializerType: "custom",
         urlVar: "cy",
         serialize: (settings, key) => serializeCovidYears(settings[key]),
-          deserialize: (settings, s) => deserializeCovidYears(s),
+        deserialize: (settings, s) => deserializeCovidYears(s),
       },
-    ]
+    ],
   ];
 }
-import type { SortOrder, SortType, YScale, FacetLimit } from "utilities/ChartOptions";
-import type { SchoolFilters, GradeLevelFilters, TestAdministrationFilters, StudentGroupFilters, TestSubjectFilters } from "utilities/DistrictData";
+import type {
+  SortOrder,
+  SortType,
+  YScale,
+  FacetLimit,
+} from "utilities/ChartOptions";
+import type {
+  SchoolFilters,
+  GradeLevelFilters,
+  TestAdministrationFilters,
+  StudentGroupFilters,
+  TestSubjectFilters,
+} from "utilities/DistrictData";
+import { METRICS_DATASETS } from "utilities/ChartableMetrics";
+import { VITALS_DATASETS } from "utilities/ChartableVitals";
 
-export type AssessmentSettings = DatasetSettings & SchoolFilters & GradeLevelFilters & TestAdministrationFilters & StudentGroupFilters & TestSubjectFilters;
+export type AssessmentSettings = DatasetSettings &
+  SchoolFilters &
+  GradeLevelFilters &
+  TestAdministrationFilters &
+  StudentGroupFilters &
+  TestSubjectFilters;
 
 const DEFAULT_ASSESSMENTS_SETTINGS = DEFAULT_DATASET_SETTINGS.map((v) => ({
   ...v,
@@ -103,7 +129,7 @@ export type AssessmentContextSettings = CommonFacetContextSettings<Facet> & {
   disclosureAvoidance: DisclosureAvoidance;
 };
 
-const DEFAULT_DASHBOARD_SETTINGS : AssessmentContextSettings = {
+const DEFAULT_DASHBOARD_SETTINGS: AssessmentContextSettings = {
   ...DEFAULT_COMMON_FACET_CONTEXT_SETTINGS,
   sortType: "latest" as const,
   yScale: "fixed" as const,
@@ -122,7 +148,10 @@ export const SERIALIZE_ASSESSMENTS_SETTINGS_GENERATORS = [
 ];
 
 export const SERIALIZE_ASSESSMENTS_CONTEXT_SETTINGS_GENERATORS = [
-  CommonContextSettingsAll.makeFacetSerializeConfigHelper<Facet>(serializeFacet, deserializeFacet),
+  CommonContextSettingsAll.makeFacetSerializeConfigHelper<Facet>(
+    serializeFacet,
+    deserializeFacet,
+  ),
   CommonContextSettingsAll.makeSortOrderSerializeConfig,
   CommonContextSettingsAll.makeSortOrderSerializeConfig,
   CommonContextSettingsAll.makeYScaleSerializeConfig,
@@ -138,9 +167,11 @@ export default function AssessmentPage() {
       defaultAllSettings={DEFAULT_ASSESSMENTS_SETTINGS}
       allSettingsConfigGenerators={SERIALIZE_ASSESSMENTS_SETTINGS_GENERATORS}
       defaultContextSettings={DEFAULT_DASHBOARD_SETTINGS}
-      contextSettingsConfigGenerators={SERIALIZE_ASSESSMENTS_CONTEXT_SETTINGS_GENERATORS}
+      contextSettingsConfigGenerators={
+        SERIALIZE_ASSESSMENTS_CONTEXT_SETTINGS_GENERATORS
+      }
       ContentComponent={AssessmentDashboard}
+      datasets={[...METRICS_DATASETS, ...VITALS_DATASETS, "assessment"]}
     />
   );
 }
-

--- a/app/finance/correlations/CorrelationsPage.tsx
+++ b/app/finance/correlations/CorrelationsPage.tsx
@@ -1,6 +1,9 @@
 "use client";
 
-import { DEFAULT_COMMON_CONTEXT_SETTINGS, makeChartsEnabledSerializeConfig } from "app/finance/_settings/common_context_settings";
+import {
+  DEFAULT_COMMON_CONTEXT_SETTINGS,
+  makeChartsEnabledSerializeConfig,
+} from "app/finance/_settings/common_context_settings";
 import { DEFAULT_DATASET_SETTINGS } from "app/finance/_settings/dataset_settings";
 import * as CommonSettings from "app/finance/_settings/common_settings";
 import { EnsureDistrictData } from "app/finance/_providers/DistrictDataProvider";
@@ -8,12 +11,12 @@ import { makeDefaultDatasetSettings } from "app/finance/_settings/common_setting
 import CorrelationsDashboard from "./CorrelationsDashboard";
 
 import type { DatasetSettings } from "app/finance/_settings/dataset_settings";
+import { VITALS_DATASETS } from "utilities/ChartableVitals";
 
 export type CorrelationsSettings = DatasetSettings;
 
-
 export const DEFAULT_CORRELATIONS_SETTINGS = DEFAULT_DATASET_SETTINGS.map(
-  v => ({
+  (v) => ({
     ...v,
     ...makeDefaultDatasetSettings(v.ccddd),
   }),
@@ -33,10 +36,11 @@ export default function CorrelationsPage() {
       defaultAllSettings={DEFAULT_CORRELATIONS_SETTINGS}
       allSettingsConfigGenerators={SERIALIZE_CORRELATIONS_SETTINGS_GENERATORS}
       defaultContextSettings={DEFAULT_COMMON_CONTEXT_SETTINGS}
-      contextSettingsConfigGenerators={SERIALIZE_CORRELATIONS_CONTEXT_SETTINGS_GENERATORS}
+      contextSettingsConfigGenerators={
+        SERIALIZE_CORRELATIONS_CONTEXT_SETTINGS_GENERATORS
+      }
       ContentComponent={CorrelationsDashboard}
+      datasets={[...VITALS_DATASETS]}
     />
   );
 }
-
-

--- a/app/finance/detailedactuals/DetailedActualsPage.tsx
+++ b/app/finance/detailedactuals/DetailedActualsPage.tsx
@@ -13,19 +13,33 @@ import DetailedActualsDashboard from "./DetailedActualsDashboard";
 import type { DatasetSettings } from "app/finance/_settings/dataset_settings";
 import type { Facet } from "./DetailedActualsDashboard";
 import type { CommonFacetContextSettings } from "app/finance/_settings/common_context_settings";
-import type { SortOrder, SortType, YScale, FacetLimit } from "utilities/ChartOptions";
-import type { PAOFilters, SchoolFilters, NcesFilters } from "utilities/DistrictData";
+import type {
+  SortOrder,
+  SortType,
+  YScale,
+  FacetLimit,
+} from "utilities/ChartOptions";
+import type {
+  PAOFilters,
+  SchoolFilters,
+  NcesFilters,
+} from "utilities/DistrictData";
+import { METRICS_DATASETS } from "utilities/ChartableMetrics";
+import { VITALS_DATASETS } from "utilities/ChartableVitals";
 
-export type DetailedActualsSettings = DatasetSettings & PAOFilters & SchoolFilters & NcesFilters;
+export type DetailedActualsSettings = DatasetSettings &
+  PAOFilters &
+  SchoolFilters &
+  NcesFilters;
 
 const DEFAULT_DETAILED_ACTUALS_SETTINGS = DEFAULT_DATASET_SETTINGS.map((v) => ({
   ...v,
-  ...makeDefaultSettings(v.ccddd)
+  ...makeDefaultSettings(v.ccddd),
 }));
 
 export type DetailedActualsContextSettings = CommonFacetContextSettings<Facet>;
 
-const DEFAULT_DASHBOARD_SETTINGS : DetailedActualsContextSettings = {
+const DEFAULT_DASHBOARD_SETTINGS: DetailedActualsContextSettings = {
   ...DEFAULT_COMMON_FACET_CONTEXT_SETTINGS,
   facet: "nces",
 };
@@ -39,7 +53,10 @@ export const SERIALIZE_DETAILED_ACTUALS_SETTINGS_GENERATORS = [
 ];
 
 export const SERIALIZE_DETAILED_ACTUALS_CONTEXT_SETTINGS_GENERATORS = [
-  CommonContextSettingsAll.makeFacetSerializeConfigHelper<Facet>(serializeFacet, deserializeFacet),
+  CommonContextSettingsAll.makeFacetSerializeConfigHelper<Facet>(
+    serializeFacet,
+    deserializeFacet,
+  ),
   CommonContextSettingsAll.makeSortOrderSerializeConfig,
   CommonContextSettingsAll.makeSortOrderSerializeConfig,
   CommonContextSettingsAll.makeYScaleSerializeConfig,
@@ -51,11 +68,15 @@ export default function DetailedActualsPage() {
   return (
     <EnsureDistrictData
       defaultAllSettings={DEFAULT_DETAILED_ACTUALS_SETTINGS}
-      allSettingsConfigGenerators={SERIALIZE_DETAILED_ACTUALS_SETTINGS_GENERATORS}
+      allSettingsConfigGenerators={
+        SERIALIZE_DETAILED_ACTUALS_SETTINGS_GENERATORS
+      }
       defaultContextSettings={DEFAULT_DASHBOARD_SETTINGS}
-      contextSettingsConfigGenerators={SERIALIZE_DETAILED_ACTUALS_CONTEXT_SETTINGS_GENERATORS}
+      contextSettingsConfigGenerators={
+        SERIALIZE_DETAILED_ACTUALS_CONTEXT_SETTINGS_GENERATORS
+      }
       ContentComponent={DetailedActualsDashboard}
+      datasets={[...METRICS_DATASETS, ...VITALS_DATASETS]}
     />
   );
 }
-

--- a/app/finance/enrollment/EnrollmentPage.tsx
+++ b/app/finance/enrollment/EnrollmentPage.tsx
@@ -15,7 +15,13 @@ import type { SettingsConfig } from "app/finance/_settings/base_settings";
 import type { DatasetSettings } from "app/finance/_settings/dataset_settings";
 import type { Facet } from "./EnrollmentDashboard";
 import type { CommonFacetContextSettings } from "app/finance/_settings/common_context_settings";
-import type { SchoolFilters, GradeLevelFilters, StudentGroupFilters } from "utilities/DistrictData";
+import type {
+  SchoolFilters,
+  GradeLevelFilters,
+  StudentGroupFilters,
+} from "utilities/DistrictData";
+import { METRICS_DATASETS } from "utilities/ChartableMetrics";
+import { VITALS_DATASETS } from "utilities/ChartableVitals";
 
 // When on, force diploma_year as an extra series dim regardless of
 // breakdown selection — overlays cohort lines on top of any breakdown.
@@ -24,13 +30,14 @@ import type { SchoolFilters, GradeLevelFilters, StudentGroupFilters } from "util
 function makeEnrollmentCohortLinesSerializeConfig(context?): SettingsConfig {
   return [
     [
-      "cohortLines", {
+      "cohortLines",
+      {
         serializerType: "custom",
         urlVar: "ecl",
-        serialize: (settings, key) => settings[key] ? "1" : "0",
+        serialize: (settings, key) => (settings[key] ? "1" : "0"),
         deserialize: (settings, s) => s === "1",
       },
-    ]
+    ],
   ];
 }
 
@@ -41,13 +48,14 @@ function makeEnrollmentCohortLinesSerializeConfig(context?): SettingsConfig {
 function makeEnrollmentDeltaModeSerializeConfig(context?): SettingsConfig {
   return [
     [
-      "deltaMode", {
+      "deltaMode",
+      {
         serializerType: "custom",
         urlVar: "edm",
-        serialize: (settings, key) => settings[key] ? "1" : "0",
+        serialize: (settings, key) => (settings[key] ? "1" : "0"),
         deserialize: (settings, s) => s === "1",
       },
-    ]
+    ],
   ];
 }
 
@@ -60,7 +68,8 @@ export const ENROLLMENT_CLASS_OF_MAX = 2030;
 function makeEnrollmentClassOfRangeSerializeConfig(context?): SettingsConfig {
   return [
     [
-      "classOfMin", {
+      "classOfMin",
+      {
         serializerType: "custom",
         urlVar: "ecmn",
         serialize: (settings, key) => String(settings[key]),
@@ -69,8 +78,10 @@ function makeEnrollmentClassOfRangeSerializeConfig(context?): SettingsConfig {
           return Number.isFinite(n) ? n : ENROLLMENT_CLASS_OF_MIN;
         },
       },
-    ], [
-      "classOfMax", {
+    ],
+    [
+      "classOfMax",
+      {
         serializerType: "custom",
         urlVar: "ecmx",
         serialize: (settings, key) => String(settings[key]),
@@ -79,7 +90,7 @@ function makeEnrollmentClassOfRangeSerializeConfig(context?): SettingsConfig {
           return Number.isFinite(n) ? n : ENROLLMENT_CLASS_OF_MAX;
         },
       },
-    ]
+    ],
   ];
 }
 
@@ -117,26 +128,34 @@ export function deserializeEnrollmentBreakdown(s: string): EnrollmentBreakdown {
 function makeEnrollmentBreakdownSerializeConfig(context?): SettingsConfig {
   return [
     [
-      "breakdown", {
+      "breakdown",
+      {
         serializerType: "custom",
         urlVar: "ebd",
-        serialize: (settings, key) => serializeEnrollmentBreakdown(settings[key]),
-          deserialize: (settings, s) => deserializeEnrollmentBreakdown(s),
+        serialize: (settings, key) =>
+          serializeEnrollmentBreakdown(settings[key]),
+        deserialize: (settings, s) => deserializeEnrollmentBreakdown(s),
       },
-    ]
+    ],
   ];
 }
 
 // codeColumn name on the enrollment frame for each breakdown choice.
 // "none" maps to null so the dashboard skips per-series splitting.
-export const ENROLLMENT_BREAKDOWN_CODE_COLUMNS: Record<EnrollmentBreakdown, string | null> = {
+export const ENROLLMENT_BREAKDOWN_CODE_COLUMNS: Record<
+  EnrollmentBreakdown,
+  string | null
+> = {
   none: null,
   grade: "grade_level_code",
   grade_cohort: "grade_cohort_code",
 };
 
 // Display-label column for each breakdown choice (used in chart legends).
-export const ENROLLMENT_BREAKDOWN_LABEL_COLUMNS: Record<EnrollmentBreakdown, string | null> = {
+export const ENROLLMENT_BREAKDOWN_LABEL_COLUMNS: Record<
+  EnrollmentBreakdown,
+  string | null
+> = {
   none: null,
   grade: "grade_level",
   grade_cohort: "grade_cohort",
@@ -145,28 +164,33 @@ export const ENROLLMENT_BREAKDOWN_LABEL_COLUMNS: Record<EnrollmentBreakdown, str
 function makeEnrollmentGradeLevelSerializeConfig(context?): SettingsConfig {
   return [
     [
-      "gradeLevelCodes", {
+      "gradeLevelCodes",
+      {
         serializerType: "filter",
         urlVar: "egl",
         filter: EnrollmentGradeLevelFilter,
       },
-    ]
+    ],
   ];
 }
 
 function makeEnrollmentStudentGroupFilterConfig(context?): SettingsConfig {
   return [
     [
-      "studentGroupCodes", {
+      "studentGroupCodes",
+      {
         serializerType: "filter",
         urlVar: "esgf",
         filter: EnrollmentStudentGroupFilter,
       },
-    ]
+    ],
   ];
 }
 
-export type EnrollmentSettings = DatasetSettings & SchoolFilters & GradeLevelFilters & StudentGroupFilters;
+export type EnrollmentSettings = DatasetSettings &
+  SchoolFilters &
+  GradeLevelFilters &
+  StudentGroupFilters;
 
 const DEFAULT_DETAILED_ACTUALS_SETTINGS = DEFAULT_DATASET_SETTINGS.map((v) => ({
   ...v,
@@ -185,7 +209,7 @@ export type EnrollmentContextSettings = CommonFacetContextSettings<Facet> & {
   classOfMax: number;
 };
 
-const DEFAULT_DASHBOARD_SETTINGS : EnrollmentContextSettings = {
+const DEFAULT_DASHBOARD_SETTINGS: EnrollmentContextSettings = {
   ...DEFAULT_COMMON_FACET_CONTEXT_SETTINGS,
   sortType: "latest" as const,
   facet: "ms_assignment" as const,
@@ -204,7 +228,10 @@ export const SERIALIZE_DETAILED_ACTUALS_SETTINGS_GENERATORS = [
 ];
 
 export const SERIALIZE_DETAILED_ACTUALS_CONTEXT_SETTINGS_GENERATORS = [
-  CommonContextSettingsAll.makeFacetSerializeConfigHelper<Facet>(serializeFacet, deserializeFacet),
+  CommonContextSettingsAll.makeFacetSerializeConfigHelper<Facet>(
+    serializeFacet,
+    deserializeFacet,
+  ),
   CommonContextSettingsAll.makeYScaleSerializeConfig,
   CommonContextSettingsAll.makeSchoolGroupingSerializeConfig,
   CommonContextSettingsAll.makeChartsEnabledSerializeConfig,
@@ -219,11 +246,15 @@ export default function EnrollmentPage() {
   return (
     <EnsureDistrictData
       defaultAllSettings={DEFAULT_DETAILED_ACTUALS_SETTINGS}
-      allSettingsConfigGenerators={SERIALIZE_DETAILED_ACTUALS_SETTINGS_GENERATORS}
+      allSettingsConfigGenerators={
+        SERIALIZE_DETAILED_ACTUALS_SETTINGS_GENERATORS
+      }
       defaultContextSettings={DEFAULT_DASHBOARD_SETTINGS}
-      contextSettingsConfigGenerators={SERIALIZE_DETAILED_ACTUALS_CONTEXT_SETTINGS_GENERATORS}
+      contextSettingsConfigGenerators={
+        SERIALIZE_DETAILED_ACTUALS_CONTEXT_SETTINGS_GENERATORS
+      }
       ContentComponent={EnrollmentDashboard}
+      datasets={[...METRICS_DATASETS, ...VITALS_DATASETS, "enrollment"]}
     />
   );
 }
-

--- a/app/finance/expenditures/ExpendituresPage.tsx
+++ b/app/finance/expenditures/ExpendituresPage.tsx
@@ -4,22 +4,32 @@ import { DEFAULT_DATASET_SETTINGS } from "app/finance/_settings/dataset_settings
 import * as CommonContextSettings from "app/finance/_settings/common_context_settings";
 import * as CommonSettings from "app/finance/_settings/common_settings";
 import { EnsureDistrictData } from "app/finance/_providers/DistrictDataProvider";
-import { makeDefaultPaoSettings, makeDefaultDatasetSettings } from "app/finance/_settings/common_settings";
+import {
+  makeDefaultPaoSettings,
+  makeDefaultDatasetSettings,
+} from "app/finance/_settings/common_settings";
 import ExpendituresDashboard from "./ExpendituresDashboard";
-import { DEFAULT_DASHBOARD_SETTINGS, serializeExpendituresDashbaordFacet, deserializeExpendituresDashbaordFacet } from "./ExpendituresContextSettings";
+import {
+  DEFAULT_DASHBOARD_SETTINGS,
+  serializeExpendituresDashbaordFacet,
+  deserializeExpendituresDashbaordFacet,
+} from "./ExpendituresContextSettings";
 
 import type { Facet } from "./ExpendituresContextSettings";
 
 import type { DatasetSettings } from "app/finance/_settings/dataset_settings";
 import type { PAOFilters } from "utilities/DistrictData";
 import type { SettingsConfig } from "app/finance/_settings/base_settings";
+import { METRICS_DATASETS } from "utilities/ChartableMetrics";
+import { VITALS_DATASETS } from "utilities/ChartableVitals";
 
-export type ExpendituresSettings = DatasetSettings & PAOFilters & {
-  overridePrimaryFilter: boolean;
-};
+export type ExpendituresSettings = DatasetSettings &
+  PAOFilters & {
+    overridePrimaryFilter: boolean;
+  };
 
 export const DEFAULT_EXPENDITURES_SETTINGS = DEFAULT_DATASET_SETTINGS.map(
-  v => ({
+  (v) => ({
     ...v,
     overridePrimaryFilter: false,
     ...makeDefaultDatasetSettings(v.ccddd),
@@ -27,7 +37,7 @@ export const DEFAULT_EXPENDITURES_SETTINGS = DEFAULT_DATASET_SETTINGS.map(
   }),
 );
 
-function makeExpenditreDatasetSerializeConfig(context?) : SettingsConfig {
+function makeExpenditreDatasetSerializeConfig(context?): SettingsConfig {
   return [
     [
       "overridePrimaryFilter",
@@ -35,8 +45,8 @@ function makeExpenditreDatasetSerializeConfig(context?) : SettingsConfig {
         serializerType: "custom",
         urlVar: "of",
         serialize: (settings, key) => (settings[key] ? "1" : "0"),
-          deserialize: (settings, s) => (s === "1" ? true : false)
-      }
+        deserialize: (settings, s) => (s === "1" ? true : false),
+      },
     ],
   ];
 }
@@ -50,7 +60,8 @@ export const SERIALIZE_EXPENDITURES_SETTINGS_GENERATORS = [
 export const SERIALIZE_EXPENDITURES_CONTEXT_SETTINGS_GENERATORS = [
   CommonContextSettings.makeFacetSerializeConfigHelper<Facet>(
     serializeExpendituresDashbaordFacet,
-    deserializeExpendituresDashbaordFacet),
+    deserializeExpendituresDashbaordFacet,
+  ),
   CommonContextSettings.makeSortOrderSerializeConfig,
   CommonContextSettings.makeYScaleSerializeConfig,
   CommonContextSettings.makeChartsEnabledSerializeConfig,
@@ -62,8 +73,11 @@ export default function ExpendituresPage() {
       defaultAllSettings={DEFAULT_EXPENDITURES_SETTINGS}
       allSettingsConfigGenerators={SERIALIZE_EXPENDITURES_SETTINGS_GENERATORS}
       defaultContextSettings={DEFAULT_DASHBOARD_SETTINGS}
-      contextSettingsConfigGenerators={SERIALIZE_EXPENDITURES_CONTEXT_SETTINGS_GENERATORS}
+      contextSettingsConfigGenerators={
+        SERIALIZE_EXPENDITURES_CONTEXT_SETTINGS_GENERATORS
+      }
       ContentComponent={ExpendituresDashboard}
+      datasets={[...METRICS_DATASETS, ...VITALS_DATASETS]}
     />
   );
 }

--- a/app/finance/flow/FlowPage.tsx
+++ b/app/finance/flow/FlowPage.tsx
@@ -16,6 +16,13 @@ export default function FlowPage() {
       defaultContextSettings={DEFAULT_COMMON_CONTEXT_SETTINGS}
       contextSettingsConfigGenerators={[]}
       ContentComponent={FlowDashboard}
+      datasets={[
+        "enrollment",
+        "gf_expenditures",
+        "gf_revenues",
+        // all_class_ofs() spans three frames, this being the third.
+        "fundedEnrollment",
+      ]}
     />
   );
 }

--- a/app/finance/revenues/RevenuesPage.tsx
+++ b/app/finance/revenues/RevenuesPage.tsx
@@ -24,6 +24,7 @@ import type {
   RevenueAccountFilters,
   PFilters,
 } from "utilities/DistrictData";
+import { VITALS_DATASETS } from "utilities/ChartableVitals";
 
 export type RevenuesSettings = DatasetSettings &
   RevenueCategoryFilters &
@@ -63,6 +64,7 @@ export default function RevenuesPage() {
         SERIALIZE_REVENUES_CONTEXT_SETTINGS_GENERATORS
       }
       ContentComponent={RevenuesDashboard}
+      datasets={[...VITALS_DATASETS]}
     />
   );
 }

--- a/app/finance/salaries/SalariesDashboard.tsx
+++ b/app/finance/salaries/SalariesDashboard.tsx
@@ -1,0 +1,222 @@
+"use client";
+
+// Salaries dashboard: every S-275 total_final_salary for one district and
+// year, one column per person, grouped by duty title and wrapped across rows.
+//
+// This fetches `s275_salaries` itself rather than going through DistrictData.
+// That dataset is one row per employee (~82k rows across all years for SPS)
+// and only this page reads it, so loading it in the shared provider would put
+// it on the wire for every finance dashboard.
+
+import Alert from "@mui/material/Alert";
+import CircularProgress from "@mui/material/CircularProgress";
+import Link from "@mui/material/Link";
+import Stack from "@mui/material/Stack";
+import Typography from "@mui/material/Typography";
+import { useEffect, useMemo, useState } from "react";
+
+import SettingsLayout from "app/finance/_widgets/SettingsLayout";
+import { DutyRootFilterContents } from "app/finance/_widgets/ExpenditureFilterContents";
+import {
+  serializeDatasetSettings,
+  serializeOneSetting,
+} from "app/finance/_settings/common_settings";
+import { fetchDataset } from "utilities/client/FetchData";
+
+import SalarySkyline from "./SalarySkyline";
+import {
+  RowWidthContents,
+  SalariesDatasetContents,
+  SchoolYearContents,
+} from "./SalariesSettingsContents";
+import { groupByDuty, planRows } from "./rowPlan";
+import {
+  SERIALIZE_SALARIES_CONTEXT_SETTINGS_GENERATORS,
+  SERIALIZE_SALARIES_SETTINGS_GENERATORS,
+} from "./settings";
+
+import type { Person } from "./rowPlan";
+import type { SalariesContextSettings, SalariesSettings } from "./settings";
+
+type Row = {
+  school_year: string;
+  duty_root: string | null;
+  duty_root_code: number | null;
+  total_final_salary: unknown;
+  fte: unknown;
+};
+
+type Result = { ccddd: number; rows: Row[] | null };
+
+// Avro decimal columns arrive as a Decimal wrapper, JSON fixtures as strings,
+// and plain ints as numbers; normalize before doing arithmetic on any of them.
+function num(v: unknown): number {
+  if (v === null || v === undefined) return 0;
+  if (typeof v === "number") return v;
+  const maybe = v as { toNumber?: () => number };
+  return typeof maybe.toNumber === "function" ? maybe.toNumber() : Number(v);
+}
+
+type Props = {
+  allSettings: Array<SalariesSettings>;
+  contextSettings: SalariesContextSettings;
+};
+
+export default function SalariesDashboard({
+  allSettings,
+  contextSettings,
+}: Props) {
+  const settings = allSettings[0];
+  const ccddd = settings.ccddd;
+  // The result carries the district it belongs to, so a stale result for the
+  // previous district reads as "still loading" without an effect having to
+  // synchronously clear state on every change.
+  const [result, setResult] = useState<Result | null>(null);
+
+  useEffect(() => {
+    let live = true;
+    fetchDataset(ccddd, "s275_salaries")
+      .then((table) => {
+        if (live) setResult({ ccddd, rows: table.objects() as Row[] });
+      })
+      .catch((err) => {
+        if (!live) return;
+        console.error("s275_salaries fetch failed", err);
+        setResult({ ccddd, rows: null });
+      });
+    return () => {
+      live = false;
+    };
+  }, [ccddd]);
+
+  const current = result?.ccddd === ccddd ? result : null;
+  const rows = current?.rows ?? null;
+  const failed = current !== null && current.rows === null;
+
+  const years = useMemo(() => {
+    if (!rows) return [];
+    return [...new Set(rows.map((r) => r.school_year))].sort().reverse();
+  }, [rows]);
+
+  // "" (or a year this district never filed) falls back to the newest year
+  // present rather than rendering an empty chart.
+  const year = years.includes(contextSettings.year)
+    ? contextSettings.year
+    : (years[0] ?? "");
+
+  const people: Person[] = useMemo(() => {
+    if (!rows || !year) return [];
+    return rows
+      .filter(
+        (r) =>
+          r.school_year === year &&
+          (r.duty_root_code === null ||
+            settings.dutyRootCodes.has(r.duty_root_code)),
+      )
+      .map((r) => ({
+        duty: r.duty_root ?? `Duty ${r.duty_root_code ?? "unknown"}`,
+        salary: num(r.total_final_salary),
+        fte: num(r.fte),
+      }))
+      .filter((p) => p.salary > 0);
+  }, [rows, year, settings.dutyRootCodes]);
+
+  const plan = useMemo(
+    () => planRows(people, contextSettings.peoplePerRow),
+    [people, contextSettings.peoplePerRow],
+  );
+
+  const colorOf = useMemo(() => {
+    const map = new Map<string, number>();
+    let i = 0;
+    for (const duty of groupByDuty(people).keys()) map.set(duty, i++);
+    return map;
+  }, [people]);
+
+  const payroll = people.reduce((sum, p) => sum + p.salary, 0);
+  const fte = people.reduce((sum, p) => sum + p.fte, 0);
+
+  // The year selector can only offer what the loaded data actually has, so it
+  // is bound here rather than in the settings module.
+  const YearContents = useMemo(
+    () =>
+      function BoundSchoolYearContents(props) {
+        return <SchoolYearContents {...props} years={years} />;
+      },
+    [years],
+  );
+
+  return (
+    <SettingsLayout
+      settingsSerializer={{
+        serialize: (newAllSettings) =>
+          serializeDatasetSettings(
+            newAllSettings,
+            SERIALIZE_SALARIES_SETTINGS_GENERATORS,
+          ),
+        serializeContext: (context) =>
+          serializeOneSetting(
+            context,
+            SERIALIZE_SALARIES_CONTEXT_SETTINGS_GENERATORS,
+          ),
+      }}
+      allSettings={allSettings}
+      contextSettings={contextSettings}
+      contextSettingsComponents={[YearContents, RowWidthContents]}
+      settingsContentsComponents={[
+        SalariesDatasetContents,
+        DutyRootFilterContents,
+      ]}
+      // One skyline at a time: two districts' payrolls overlaid on one axis
+      // would not be readable, and the rows are already the comparison unit.
+      hideAddComparison
+    >
+      <Typography className="analysis-title" component="h1" variant="h1">
+        Salaries
+      </Typography>
+      <Typography variant="body2" sx={{ color: "text.secondary", mb: 2 }}>
+        Every S-275 <code>total_final_salary</code> for the year, one column per
+        person, grouped by the duty title of their major assignment and sorted
+        by salary within each duty. Rows wrap; every row shares the same salary
+        scale and the same number of slots, so heights and horizontal positions
+        are comparable between them. A variant of the{" "}
+        <Link href="/analyses/seattle_sea_pay_gap.html">
+          SEA pay-gap analysis
+        </Link>{" "}
+        chart.
+      </Typography>
+
+      {failed && (
+        <Alert severity="info" sx={{ mb: 2 }}>
+          The per-employee salary dataset is not available for this district
+          yet.
+        </Alert>
+      )}
+
+      {!current && (
+        <Stack direction="row" spacing={1} alignItems="center">
+          <CircularProgress size={18} />
+          <Typography variant="body2">Loading salaries…</Typography>
+        </Stack>
+      )}
+
+      {rows && people.length === 0 && year && (
+        <Typography variant="body2" sx={{ color: "text.secondary" }}>
+          No salaries match the selected duty titles for {year}.
+        </Typography>
+      )}
+
+      {rows && people.length > 0 && (
+        <>
+          <Typography variant="body2" sx={{ mb: 1.5 }}>
+            <b>{people.length.toLocaleString()}</b> people ·{" "}
+            <b>{fte.toLocaleString(undefined, { maximumFractionDigits: 0 })}</b>{" "}
+            FTE · <b>${(payroll / 1e6).toFixed(1)}M</b> in salaries ·{" "}
+            {colorOf.size} duty titles · {year}
+          </Typography>
+          <SalarySkyline plan={plan} colorOf={colorOf} year={year} />
+        </>
+      )}
+    </SettingsLayout>
+  );
+}

--- a/app/finance/salaries/SalariesDashboard.tsx
+++ b/app/finance/salaries/SalariesDashboard.tsx
@@ -16,7 +16,11 @@ import Typography from "@mui/material/Typography";
 import { useEffect, useMemo, useState } from "react";
 
 import SettingsLayout from "app/finance/_widgets/SettingsLayout";
-import { DutyRootFilterContents } from "app/finance/_widgets/ExpenditureFilterContents";
+import {
+  ActivityFilterContents,
+  DutyRootFilterContents,
+  ProgramFilterContents,
+} from "app/finance/_widgets/ExpenditureFilterContents";
 import {
   serializeDatasetSettings,
   serializeOneSetting,
@@ -42,6 +46,11 @@ type Row = {
   school_year: string;
   duty_root: string | null;
   duty_root_code: number | null;
+  // Program and activity were added to the dataset after the first deploy, so
+  // treat them as optional: an older cached export simply has no such column,
+  // and the filters below pass everything through rather than empty the chart.
+  program_code?: number | null;
+  activity_code?: number | null;
   total_final_salary: unknown;
   fte: unknown;
 };
@@ -106,12 +115,15 @@ export default function SalariesDashboard({
 
   const people: Person[] = useMemo(() => {
     if (!rows || !year) return [];
+    const passes = (code: number | null | undefined, codes: Set<number>) =>
+      code === null || code === undefined || codes.has(code);
     return rows
       .filter(
         (r) =>
           r.school_year === year &&
-          (r.duty_root_code === null ||
-            settings.dutyRootCodes.has(r.duty_root_code)),
+          passes(r.duty_root_code, settings.dutyRootCodes) &&
+          passes(r.program_code, settings.programCodes) &&
+          passes(r.activity_code, settings.activityCodes),
       )
       .map((r) => ({
         duty: r.duty_root ?? `Duty ${r.duty_root_code ?? "unknown"}`,
@@ -119,7 +131,13 @@ export default function SalariesDashboard({
         fte: num(r.fte),
       }))
       .filter((p) => p.salary > 0);
-  }, [rows, year, settings.dutyRootCodes]);
+  }, [
+    rows,
+    year,
+    settings.dutyRootCodes,
+    settings.programCodes,
+    settings.activityCodes,
+  ]);
 
   const plan = useMemo(
     () => planRows(people, contextSettings.peoplePerRow),
@@ -166,6 +184,8 @@ export default function SalariesDashboard({
       settingsContentsComponents={[
         SalariesDatasetContents,
         DutyRootFilterContents,
+        ProgramFilterContents,
+        ActivityFilterContents,
       ]}
       // One skyline at a time: two districts' payrolls overlaid on one axis
       // would not be readable, and the rows are already the comparison unit.

--- a/app/finance/salaries/SalariesPage.tsx
+++ b/app/finance/salaries/SalariesPage.tsx
@@ -19,7 +19,6 @@ import Typography from "@mui/material/Typography";
 import { useEffect, useMemo, useState } from "react";
 
 import DistrictSelector from "app/finance/_widgets/DistrictSelector";
-import FinanceSubNav from "app/finance/_widgets/FinanceSubNav";
 import { fetchDataset } from "utilities/client/FetchData";
 
 import SalarySkyline from "./SalarySkyline";
@@ -113,77 +112,72 @@ export default function SalariesPage() {
   const fte = people.reduce((sum, p) => sum + p.fte, 0);
 
   return (
-    <>
-      <FinanceSubNav />
-      <Box sx={{ p: 3 }}>
-        <Typography component="h1" variant="h4" gutterBottom>
-          Salaries
-        </Typography>
-        <Typography variant="body2" sx={{ color: "text.secondary", mb: 2 }}>
-          Every S-275 <code>total_final_salary</code> for the year, one column
-          per person, grouped by the duty title of their major assignment and
-          sorted by salary within each duty. Rows wrap; every row shares the
-          same salary scale and the same number of slots, so heights and
-          horizontal positions are comparable between them. A variant of the{" "}
-          <Link href="/analyses/seattle_sea_pay_gap.html">
-            SEA pay-gap analysis
-          </Link>{" "}
-          chart.
-        </Typography>
+    <Box sx={{ p: 3 }}>
+      <Typography component="h1" variant="h4" gutterBottom>
+        Salaries
+      </Typography>
+      <Typography variant="body2" sx={{ color: "text.secondary", mb: 2 }}>
+        Every S-275 <code>total_final_salary</code> for the year, one column per
+        person, grouped by the duty title of their major assignment and sorted
+        by salary within each duty. Rows wrap; every row shares the same salary
+        scale and the same number of slots, so heights and horizontal positions
+        are comparable between them. A variant of the{" "}
+        <Link href="/analyses/seattle_sea_pay_gap.html">
+          SEA pay-gap analysis
+        </Link>{" "}
+        chart.
+      </Typography>
 
-        <Stack direction="row" spacing={2} sx={{ mb: 2, flexWrap: "wrap" }}>
-          <DistrictSelector
-            ccddd={ccddd}
-            onChange={setCcddd}
-            sx={{ minWidth: 320 }}
-          />
-          <TextField
-            select
-            size="small"
-            label="School year"
-            value={year}
-            onChange={(e) => setYearChoice(e.target.value)}
-            disabled={years.length === 0}
-            sx={{ minWidth: 160 }}
-          >
-            {years.map((y) => (
-              <MenuItem key={y} value={y}>
-                {y}
-              </MenuItem>
-            ))}
-          </TextField>
+      <Stack direction="row" spacing={2} sx={{ mb: 2, flexWrap: "wrap" }}>
+        <DistrictSelector
+          ccddd={ccddd}
+          onChange={setCcddd}
+          sx={{ minWidth: 320 }}
+        />
+        <TextField
+          select
+          size="small"
+          label="School year"
+          value={year}
+          onChange={(e) => setYearChoice(e.target.value)}
+          disabled={years.length === 0}
+          sx={{ minWidth: 160 }}
+        >
+          {years.map((y) => (
+            <MenuItem key={y} value={y}>
+              {y}
+            </MenuItem>
+          ))}
+        </TextField>
+      </Stack>
+
+      {failed && (
+        <Alert severity="info" sx={{ mb: 2 }}>
+          The per-employee salary dataset is not available for this district
+          yet. The <code>s275_salaries</code> dataset needs the Cloud Function
+          deployed (<code>cd functions && npm run deploy</code>); until then
+          this page has nothing per-person to draw.
+        </Alert>
+      )}
+
+      {!current && (
+        <Stack direction="row" spacing={1} alignItems="center">
+          <CircularProgress size={18} />
+          <Typography variant="body2">Loading salaries…</Typography>
         </Stack>
+      )}
 
-        {failed && (
-          <Alert severity="info" sx={{ mb: 2 }}>
-            The per-employee salary dataset is not available for this district
-            yet. The <code>s275_salaries</code> dataset needs the Cloud Function
-            deployed (<code>cd functions && npm run deploy</code>); until then
-            this page has nothing per-person to draw.
-          </Alert>
-        )}
-
-        {!current && (
-          <Stack direction="row" spacing={1} alignItems="center">
-            <CircularProgress size={18} />
-            <Typography variant="body2">Loading salaries…</Typography>
-          </Stack>
-        )}
-
-        {rows && people.length > 0 && (
-          <>
-            <Typography variant="body2" sx={{ mb: 1.5 }}>
-              <b>{people.length.toLocaleString()}</b> people ·{" "}
-              <b>
-                {fte.toLocaleString(undefined, { maximumFractionDigits: 0 })}
-              </b>{" "}
-              FTE · <b>${(payroll / 1e6).toFixed(1)}M</b> in salaries ·{" "}
-              {colorOf.size} duty titles
-            </Typography>
-            <SalarySkyline plan={plan} colorOf={colorOf} year={year} />
-          </>
-        )}
-      </Box>
-    </>
+      {rows && people.length > 0 && (
+        <>
+          <Typography variant="body2" sx={{ mb: 1.5 }}>
+            <b>{people.length.toLocaleString()}</b> people ·{" "}
+            <b>{fte.toLocaleString(undefined, { maximumFractionDigits: 0 })}</b>{" "}
+            FTE · <b>${(payroll / 1e6).toFixed(1)}M</b> in salaries ·{" "}
+            {colorOf.size} duty titles
+          </Typography>
+          <SalarySkyline plan={plan} colorOf={colorOf} year={year} />
+        </>
+      )}
+    </Box>
   );
 }

--- a/app/finance/salaries/SalariesPage.tsx
+++ b/app/finance/salaries/SalariesPage.tsx
@@ -1,183 +1,44 @@
 "use client";
 
-// Salaries dashboard: every S-275 total_final_salary for one district and year,
-// one column per person, grouped by duty title and wrapped across rows.
+// Deserializes the settings drawer's URL state and hands it to the dashboard.
 //
-// This page fetches `s275_salaries` itself rather than going through
-// DistrictData. That dataset is one row per employee (~7k rows per year for
-// SPS, ~86k across all years) and only this page needs it, so loading it in
-// the shared provider would put it on the wire for every finance dashboard.
+// This is EnsureDistrictData's job on the other finance dashboards, but this
+// page does not read DistrictData at all -- it fetches the one per-employee
+// dataset it needs itself. Going through EnsureDistrictData would block the
+// first paint on ten datasets nothing here looks at.
 
-import Alert from "@mui/material/Alert";
-import Box from "@mui/material/Box";
-import CircularProgress from "@mui/material/CircularProgress";
-import Link from "@mui/material/Link";
-import MenuItem from "@mui/material/MenuItem";
-import Stack from "@mui/material/Stack";
-import TextField from "@mui/material/TextField";
-import Typography from "@mui/material/Typography";
-import { useEffect, useMemo, useState } from "react";
+import { useSearchParams } from "next/navigation";
 
-import DistrictSelector from "app/finance/_widgets/DistrictSelector";
-import { fetchDataset } from "utilities/client/FetchData";
+import { deserializeDatasetSettings } from "app/finance/_settings/common_settings";
+import { deserializeContextSettings } from "app/finance/_settings/common_context_settings";
 
-import SalarySkyline from "./SalarySkyline";
-import { groupByDuty, planRows } from "./rowPlan";
-
-import type { Person } from "./rowPlan";
-
-const SPS_CCDDD = 17001;
-const PEOPLE_PER_ROW = 1500;
-
-type Result = { ccddd: number; rows: Record[] | null };
-
-type Record = {
-  school_year: string;
-  duty_root: string | null;
-  duty_root_code: number | null;
-  total_final_salary: unknown;
-  fte: unknown;
-};
-
-// Arquero hands numeric columns back as Decimal wrappers or plain numbers
-// depending on the Avro logical type, so normalize before arithmetic.
-function num(v: unknown): number {
-  if (v === null || v === undefined) return 0;
-  if (typeof v === "number") return v;
-  const maybe = v as { toNumber?: () => number };
-  return typeof maybe.toNumber === "function" ? maybe.toNumber() : Number(v);
-}
+import SalariesDashboard from "./SalariesDashboard";
+import {
+  DEFAULT_SALARIES_CONTEXT_SETTINGS,
+  DEFAULT_SALARIES_SETTINGS,
+  SERIALIZE_SALARIES_CONTEXT_SETTINGS_GENERATORS,
+  SERIALIZE_SALARIES_SETTINGS_GENERATORS,
+} from "./settings";
 
 export default function SalariesPage() {
-  const [ccddd, setCcddd] = useState(SPS_CCDDD);
-  // The fetch result carries the district it belongs to, so a stale result
-  // for the previous district reads as "still loading" without an effect
-  // having to synchronously clear state on every change.
-  const [result, setResult] = useState<Result | null>(null);
-  const [yearChoice, setYearChoice] = useState<string | null>(null);
+  const searchParams = useSearchParams();
 
-  useEffect(() => {
-    let live = true;
-    fetchDataset(ccddd, "s275_salaries")
-      .then((table) => {
-        if (live) setResult({ ccddd, rows: table.objects() as Record[] });
-      })
-      .catch((err) => {
-        if (!live) return;
-        console.error("s275_salaries fetch failed", err);
-        setResult({ ccddd, rows: null });
-      });
-    return () => {
-      live = false;
-    };
-  }, [ccddd]);
+  const allSettings = deserializeDatasetSettings(
+    searchParams.getAll("d"),
+    DEFAULT_SALARIES_SETTINGS,
+    SERIALIZE_SALARIES_SETTINGS_GENERATORS,
+  );
 
-  const current = result?.ccddd === ccddd ? result : null;
-  const rows = current?.rows ?? null;
-  const failed = current !== null && current.rows === null;
-
-  const years = useMemo(() => {
-    if (!rows) return [];
-    return [...new Set(rows.map((r) => r.school_year))].sort().reverse();
-  }, [rows]);
-
-  // Derived rather than stored: the newest year is the default, and a year
-  // the current district has no filings for falls back to that default
-  // instead of needing an effect to correct it.
-  const year =
-    yearChoice && years.includes(yearChoice) ? yearChoice : (years[0] ?? "");
-
-  const people: Person[] = useMemo(() => {
-    if (!rows || !year) return [];
-    return rows
-      .filter((r) => r.school_year === year)
-      .map((r) => ({
-        duty: r.duty_root ?? `Duty ${r.duty_root_code ?? "unknown"}`,
-        salary: num(r.total_final_salary),
-        fte: num(r.fte),
-      }))
-      .filter((p) => p.salary > 0);
-  }, [rows, year]);
-
-  const plan = useMemo(() => planRows(people, PEOPLE_PER_ROW), [people]);
-
-  const colorOf = useMemo(() => {
-    const map = new Map<string, number>();
-    let i = 0;
-    for (const duty of groupByDuty(people).keys()) map.set(duty, i++);
-    return map;
-  }, [people]);
-
-  const payroll = people.reduce((sum, p) => sum + p.salary, 0);
-  const fte = people.reduce((sum, p) => sum + p.fte, 0);
+  const contextSettings = deserializeContextSettings(
+    searchParams.getAll("c"),
+    DEFAULT_SALARIES_CONTEXT_SETTINGS,
+    SERIALIZE_SALARIES_CONTEXT_SETTINGS_GENERATORS,
+  );
 
   return (
-    <Box sx={{ p: 3 }}>
-      <Typography component="h1" variant="h4" gutterBottom>
-        Salaries
-      </Typography>
-      <Typography variant="body2" sx={{ color: "text.secondary", mb: 2 }}>
-        Every S-275 <code>total_final_salary</code> for the year, one column per
-        person, grouped by the duty title of their major assignment and sorted
-        by salary within each duty. Rows wrap; every row shares the same salary
-        scale and the same number of slots, so heights and horizontal positions
-        are comparable between them. A variant of the{" "}
-        <Link href="/analyses/seattle_sea_pay_gap.html">
-          SEA pay-gap analysis
-        </Link>{" "}
-        chart.
-      </Typography>
-
-      <Stack direction="row" spacing={2} sx={{ mb: 2, flexWrap: "wrap" }}>
-        <DistrictSelector
-          ccddd={ccddd}
-          onChange={setCcddd}
-          sx={{ minWidth: 320 }}
-        />
-        <TextField
-          select
-          size="small"
-          label="School year"
-          value={year}
-          onChange={(e) => setYearChoice(e.target.value)}
-          disabled={years.length === 0}
-          sx={{ minWidth: 160 }}
-        >
-          {years.map((y) => (
-            <MenuItem key={y} value={y}>
-              {y}
-            </MenuItem>
-          ))}
-        </TextField>
-      </Stack>
-
-      {failed && (
-        <Alert severity="info" sx={{ mb: 2 }}>
-          The per-employee salary dataset is not available for this district
-          yet. The <code>s275_salaries</code> dataset needs the Cloud Function
-          deployed (<code>cd functions && npm run deploy</code>); until then
-          this page has nothing per-person to draw.
-        </Alert>
-      )}
-
-      {!current && (
-        <Stack direction="row" spacing={1} alignItems="center">
-          <CircularProgress size={18} />
-          <Typography variant="body2">Loading salaries…</Typography>
-        </Stack>
-      )}
-
-      {rows && people.length > 0 && (
-        <>
-          <Typography variant="body2" sx={{ mb: 1.5 }}>
-            <b>{people.length.toLocaleString()}</b> people ·{" "}
-            <b>{fte.toLocaleString(undefined, { maximumFractionDigits: 0 })}</b>{" "}
-            FTE · <b>${(payroll / 1e6).toFixed(1)}M</b> in salaries ·{" "}
-            {colorOf.size} duty titles
-          </Typography>
-          <SalarySkyline plan={plan} colorOf={colorOf} year={year} />
-        </>
-      )}
-    </Box>
+    <SalariesDashboard
+      allSettings={allSettings}
+      contextSettings={contextSettings}
+    />
   );
 }

--- a/app/finance/salaries/SalariesSettingsContents.tsx
+++ b/app/finance/salaries/SalariesSettingsContents.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+// Settings panel contents for the Salaries dashboard, rendered inside the
+// shared SettingsLayout drawer the other finance dashboards use.
+//
+// The dataset box deliberately does not reuse DatasetSettingsContents: that
+// one also renders the currency and staffing normalization selectors and the
+// filter-grouping selector, none of which mean anything here. This chart is
+// always dollars-per-person, and the only PAO-style filter it applies is the
+// duty title.
+
+import MenuItem from "@mui/material/MenuItem";
+import TextField from "@mui/material/TextField";
+
+import DistrictSelector from "app/finance/_widgets/DistrictSelector";
+import { settingsForDistrictChange } from "app/finance/_settings/common_settings";
+
+import type { SalariesContextSettings, SalariesSettings } from "./settings";
+
+// Row widths worth offering. Wider rows fit more people but make each column
+// narrower than a pixel sooner; narrower rows mean more rows to scroll.
+const ROW_WIDTHS = [750, 1000, 1500, 2500];
+
+type ContextProps = {
+  settings: SalariesContextSettings;
+  setSettings: (x: SalariesContextSettings) => void;
+  /** School years present in the loaded data, newest first. */
+  years?: string[];
+};
+
+export function SchoolYearContents({
+  settings,
+  setSettings,
+  years = [],
+}: ContextProps) {
+  // "" means "whatever the newest year in the data is", so a shared link does
+  // not pin a district to a year it may not have filed.
+  return (
+    <TextField
+      select
+      size="small"
+      fullWidth
+      label="School year"
+      value={years.includes(settings.year) ? settings.year : ""}
+      onChange={(e) => setSettings({ ...settings, year: e.target.value })}
+      disabled={years.length === 0}
+    >
+      <MenuItem value="">Most recent</MenuItem>
+      {years.map((y) => (
+        <MenuItem key={y} value={y}>
+          {y}
+        </MenuItem>
+      ))}
+    </TextField>
+  );
+}
+
+export function RowWidthContents({ settings, setSettings }: ContextProps) {
+  return (
+    <TextField
+      select
+      size="small"
+      fullWidth
+      label="People per row"
+      value={String(settings.peoplePerRow)}
+      onChange={(e) =>
+        setSettings({ ...settings, peoplePerRow: Number(e.target.value) })
+      }
+    >
+      {ROW_WIDTHS.map((n) => (
+        <MenuItem key={n} value={String(n)}>
+          {n.toLocaleString()}
+        </MenuItem>
+      ))}
+    </TextField>
+  );
+}
+
+export function SalariesDatasetContents({
+  settings,
+  setSettings,
+}: {
+  settings: SalariesSettings;
+  setSettings: (x: SalariesSettings) => void;
+}) {
+  return (
+    <DistrictSelector
+      ccddd={settings.ccddd}
+      onChange={(ccddd) =>
+        setSettings(settingsForDistrictChange(settings, ccddd))
+      }
+    />
+  );
+}

--- a/app/finance/salaries/SalarySkyline.tsx
+++ b/app/finance/salaries/SalarySkyline.tsx
@@ -37,6 +37,10 @@ const PALETTE = [
 ];
 
 const ROW_HEIGHT = 190;
+// Duties at or below this many people are drawn as columns. Worst case is one
+// SVG path per person across the small duties only, which stays in the low
+// hundreds even for a district with a long tail of one-person titles.
+const COLUMN_MAX_PEOPLE = 60;
 // Plot-area insets; the HTML label strip has to line up with these.
 const PLOT_LEFT = 62;
 const PLOT_RIGHT = 12;
@@ -65,7 +69,19 @@ function rowOptions(
   // SalarySkyline rebinding --highcharts-color-N to the same palette, gives
   // the same result whichever one takes effect.
   const series = row.segments.map((seg) => ({
-    type: "area" as const,
+    // Small duties are drawn as columns, big ones as a stepped area.
+    //
+    // A step-area only has horizontal extent between consecutive points, so a
+    // one-person duty -- Superintendent, and most of the long tail -- covers
+    // zero width and renders as nothing at all. Columns size each point
+    // exactly and do not have that problem; they were only ever a problem in
+    // bulk, where one SVG path per person locks up the renderer. Below the
+    // threshold the element count is negligible, above it the two are
+    // pixel-identical at under a pixel per person.
+    type:
+      seg.people.length <= COLUMN_MAX_PEOPLE
+        ? ("column" as const)
+        : ("area" as const),
     step: "left" as const,
     name: seg.label,
     color: PALETTE[(colorOf.get(seg.duty) ?? 0) % PALETTE.length],
@@ -119,6 +135,17 @@ function rowOptions(
       },
     },
     plotOptions: {
+      column: {
+        // Match the area's flush silhouette: no gaps, no rounded corners, and
+        // no sub-slot splitting between the series sharing this row.
+        grouping: false,
+        pointPadding: 0,
+        groupPadding: 0,
+        borderWidth: 0,
+        borderRadius: 0,
+        crisp: false,
+        animation: false,
+      },
       area: {
         // Fill to the axis, no outline and no markers: the silhouette is the
         // chart, and a marker per person would put the 7k elements back. The

--- a/app/finance/salaries/settings.ts
+++ b/app/finance/salaries/settings.ts
@@ -1,0 +1,74 @@
+// Settings for the Salaries dashboard, in the same shape the other finance
+// dashboards use so the drawer, the URL encoding and the deep links all behave
+// the same way.
+
+import * as CommonSettings from "app/finance/_settings/common_settings";
+import { DEFAULT_DATASET_SETTINGS } from "app/finance/_settings/dataset_settings";
+import DutyRootFilter from "app/finance/_filteritems/duty_root";
+
+import type {
+  BaseSettings,
+  SettingsConfig,
+} from "app/finance/_settings/base_settings";
+import type { DatasetSettings } from "app/finance/_settings/dataset_settings";
+import type { DutyRootFilters } from "utilities/DistrictData";
+
+/** Per-district settings: which district, and which duty titles to draw. */
+export type SalariesSettings = DatasetSettings & DutyRootFilters;
+
+/** Chart-wide settings. */
+export type SalariesContextSettings = BaseSettings & {
+  /** "" means the newest year present in the loaded data. */
+  year: string;
+  peoplePerRow: number;
+};
+
+export const DEFAULT_PEOPLE_PER_ROW = 1500;
+
+export const DEFAULT_SALARIES_SETTINGS: Array<SalariesSettings> =
+  DEFAULT_DATASET_SETTINGS.map((v) => ({
+    ...v,
+    dutyRootCodes: DutyRootFilter.allCodes(),
+  }));
+
+export const DEFAULT_SALARIES_CONTEXT_SETTINGS: SalariesContextSettings = {
+  id: 0,
+  name: "context",
+  year: "",
+  peoplePerRow: DEFAULT_PEOPLE_PER_ROW,
+};
+
+export const SERIALIZE_SALARIES_SETTINGS_GENERATORS = [
+  CommonSettings.makeDatasetSerializeConfig,
+  CommonSettings.makeDutyRootSerializeConfig,
+];
+
+export const SERIALIZE_SALARIES_CONTEXT_SETTINGS_GENERATORS = [
+  () =>
+    [
+      [
+        "year",
+        {
+          serializerType: "custom" as const,
+          urlVar: "y",
+          serialize: (settings, key: string) => settings[key] ?? "",
+          // A malformed year is dropped rather than pinned; the dashboard
+          // falls back to the newest year it actually has.
+          deserialize: (_settings, s: string) =>
+            /^\d{4}-\d{4}$/.test(s) ? s : "",
+        },
+      ],
+      [
+        "peoplePerRow",
+        {
+          serializerType: "custom" as const,
+          urlVar: "w",
+          serialize: (settings, key: string) => String(settings[key]),
+          deserialize: (_settings, s: string) => {
+            const n = Number(s);
+            return Number.isFinite(n) && n >= 1 ? n : DEFAULT_PEOPLE_PER_ROW;
+          },
+        },
+      ],
+    ] as SettingsConfig,
+];

--- a/app/finance/salaries/settings.ts
+++ b/app/finance/salaries/settings.ts
@@ -4,17 +4,24 @@
 
 import * as CommonSettings from "app/finance/_settings/common_settings";
 import { DEFAULT_DATASET_SETTINGS } from "app/finance/_settings/dataset_settings";
+import ActivityFilter from "app/finance/_filteritems/activity";
 import DutyRootFilter from "app/finance/_filteritems/duty_root";
+import ProgramFilter from "app/finance/_filteritems/program";
 
 import type {
   BaseSettings,
   SettingsConfig,
 } from "app/finance/_settings/base_settings";
 import type { DatasetSettings } from "app/finance/_settings/dataset_settings";
-import type { DutyRootFilters } from "utilities/DistrictData";
+import type { DutyRootFilters, PAFilters } from "utilities/DistrictData";
 
-/** Per-district settings: which district, and which duty titles to draw. */
-export type SalariesSettings = DatasetSettings & DutyRootFilters;
+/**
+ * Per-district settings: which district, and which slices of the payroll to
+ * draw. Program and activity describe where a person is mainly posted (they
+ * come from the same major assignment the duty title does), so filtering on
+ * them selects people, not fractions of anyone's salary.
+ */
+export type SalariesSettings = DatasetSettings & DutyRootFilters & PAFilters;
 
 /** Chart-wide settings. */
 export type SalariesContextSettings = BaseSettings & {
@@ -29,6 +36,8 @@ export const DEFAULT_SALARIES_SETTINGS: Array<SalariesSettings> =
   DEFAULT_DATASET_SETTINGS.map((v) => ({
     ...v,
     dutyRootCodes: DutyRootFilter.allCodes(),
+    programCodes: ProgramFilter.allCodes(),
+    activityCodes: ActivityFilter.allCodes(),
   }));
 
 export const DEFAULT_SALARIES_CONTEXT_SETTINGS: SalariesContextSettings = {
@@ -41,6 +50,7 @@ export const DEFAULT_SALARIES_CONTEXT_SETTINGS: SalariesContextSettings = {
 export const SERIALIZE_SALARIES_SETTINGS_GENERATORS = [
   CommonSettings.makeDatasetSerializeConfig,
   CommonSettings.makeDutyRootSerializeConfig,
+  CommonSettings.makePaSerializeConfig,
 ];
 
 export const SERIALIZE_SALARIES_CONTEXT_SETTINGS_GENERATORS = [
@@ -51,11 +61,17 @@ export const SERIALIZE_SALARIES_CONTEXT_SETTINGS_GENERATORS = [
         {
           serializerType: "custom" as const,
           urlVar: "y",
-          serialize: (settings, key: string) => settings[key] ?? "",
-          // A malformed year is dropped rather than pinned; the dashboard
+          // Only the ending year rides in the URL: "2024-2025" is fully
+          // determined by its second half, and that is the same class_of the
+          // rest of the codebase keys years on.
+          serialize: (settings, key: string) => {
+            const m = /^(\d{4})-(\d{4})$/.exec(settings[key] ?? "");
+            return m ? m[2] : "";
+          },
+          // Anything malformed is dropped rather than pinned; the dashboard
           // falls back to the newest year it actually has.
           deserialize: (_settings, s: string) =>
-            /^\d{4}-\d{4}$/.test(s) ? s : "",
+            /^\d{4}$/.test(s) ? `${Number(s) - 1}-${s}` : "",
         },
       ],
       [

--- a/app/finance/staffing/StaffingPage.tsx
+++ b/app/finance/staffing/StaffingPage.tsx
@@ -16,6 +16,8 @@ import type {
   PAFilters,
   SchoolFilters,
 } from "utilities/DistrictData";
+import { METRICS_DATASETS } from "utilities/ChartableMetrics";
+import { VITALS_DATASETS } from "utilities/ChartableVitals";
 
 export type StaffingSettings = DatasetSettings &
   PAFilters &
@@ -120,6 +122,7 @@ export default function StaffingPage() {
         SERIALIZE_STAFFING_CONTEXT_SETTINGS_GENERATORS
       }
       ContentComponent={StaffingDashboard}
+      datasets={[...METRICS_DATASETS, ...VITALS_DATASETS]}
     />
   );
 }

--- a/app/finance/vitals/VitalsPage.tsx
+++ b/app/finance/vitals/VitalsPage.tsx
@@ -1,6 +1,9 @@
 "use client";
 
-import { DEFAULT_COMMON_CONTEXT_SETTINGS, makeChartsEnabledSerializeConfig } from "app/finance/_settings/common_context_settings";
+import {
+  DEFAULT_COMMON_CONTEXT_SETTINGS,
+  makeChartsEnabledSerializeConfig,
+} from "app/finance/_settings/common_context_settings";
 import { DEFAULT_DATASET_SETTINGS } from "app/finance/_settings/dataset_settings";
 import * as CommonSettings from "app/finance/_settings/common_settings";
 import { EnsureDistrictData } from "app/finance/_providers/DistrictDataProvider";
@@ -8,16 +11,15 @@ import { makeDefaultDatasetSettings } from "app/finance/_settings/common_setting
 import VitalsDashboard from "./VitalsDashboard";
 
 import type { DatasetSettings } from "app/finance/_settings/dataset_settings";
+import { VITALS_DATASETS } from "utilities/ChartableVitals";
 
 export type VitalsSettings = DatasetSettings;
 
-export const DEFAULT_VITALS_SETTINGS = DEFAULT_DATASET_SETTINGS.map(
-  v => ({
-    ...v,
-    overridePrimaryFilter: false,
-    ...makeDefaultDatasetSettings(v.ccddd),
-  }),
-);
+export const DEFAULT_VITALS_SETTINGS = DEFAULT_DATASET_SETTINGS.map((v) => ({
+  ...v,
+  overridePrimaryFilter: false,
+  ...makeDefaultDatasetSettings(v.ccddd),
+}));
 
 export const SERIALIZE_VITALS_SETTINGS_GENERATORS = [
   CommonSettings.makeDatasetSerializeConfig,
@@ -33,9 +35,11 @@ export default function VitalsPage() {
       defaultAllSettings={DEFAULT_VITALS_SETTINGS}
       allSettingsConfigGenerators={SERIALIZE_VITALS_SETTINGS_GENERATORS}
       defaultContextSettings={DEFAULT_COMMON_CONTEXT_SETTINGS}
-      contextSettingsConfigGenerators={SERIALIZE_VITALS_CONTEXT_SETTINGS_GENERATORS}
+      contextSettingsConfigGenerators={
+        SERIALIZE_VITALS_CONTEXT_SETTINGS_GENERATORS
+      }
       ContentComponent={VitalsDashboard}
+      datasets={[...VITALS_DATASETS]}
     />
   );
 }
-

--- a/functions/src/finance.ts
+++ b/functions/src/finance.ts
@@ -273,7 +273,9 @@ function getS275Summary(ccddd) {
 //     over-count by roughly 5x if summed.
 //   * a person can hold assignments under several duty roots. They are counted
 //     once, under the duty of their major assignment, matching how the printed
-//     apportionment reports attribute staff.
+//     apportionment reports attribute staff. Program and activity come from
+//     that same assignment, so they describe where the person is mainly
+//     posted -- they are NOT a split of their salary across programs.
 // Verified against the SEA-critique extract: SPS 2024-25 comes back 7,156
 // people / $684.0M, the same as tools/sea_chart_critique/staff_2425.csv.
 function getS275Salaries(ccddd) {
@@ -303,17 +305,39 @@ function getS275Salaries(ccddd) {
   ),
   tot AS (
     SELECT emp, SUM(fte) fte FROM per_duty GROUP BY emp
+  ),
+  pa_pick AS (
+    SELECT
+      a.report_employee_id emp,
+      a.duty_root_code dr,
+      a.program_code pc,
+      a.activity_code ac,
+      ROW_NUMBER() OVER (
+        PARTITION BY a.report_employee_id, a.duty_root_code
+        ORDER BY a.is_major DESC, a.fte_in_assignment DESC,
+                 a.program_code, a.activity_code) rn
+    FROM
+      sps-btn-data.safs_s275.assignment a
+      JOIN sps-btn-data.safs_s275.report r ON (a.report_id = r.report_id)
+    WHERE
+      r.report_type = 'final' AND
+      r.ccddd = ${ccddd}
   )
   SELECT
     r.school_year,
     r.class_of,
     p.dr duty_root_code,
     d_dr.duty_name duty_root,
+    q.pc program_code,
+    d_p.program,
+    q.ac activity_code,
+    d_a.activity,
     pre.total_final_salary,
     t.fte
   FROM
     pick p
     JOIN tot t ON (t.emp = p.emp)
+    JOIN pa_pick q ON (q.emp = p.emp AND q.dr = p.dr AND q.rn = 1)
     JOIN sps-btn-data.safs_s275.report_employee re
       ON (re.report_employee_id = p.emp)
     JOIN sps-btn-data.safs_s275.report r ON (r.report_id = re.report_id)
@@ -321,6 +345,10 @@ function getS275Salaries(ccddd) {
       ON (pre.report_employee_id = p.emp)
     LEFT JOIN sps-btn-data.safs_domains.d_duty_root d_dr
       ON (d_dr.duty_root = p.dr)
+    LEFT JOIN sps-btn-data.safs_domains.d_program d_p
+      ON (d_p.program_code = q.pc)
+    LEFT JOIN sps-btn-data.safs_domains.d_activity d_a
+      ON (d_a.activity_code = q.ac)
   WHERE
     p.rn = 1 AND
     pre.total_final_salary IS NOT NULL

--- a/utilities/ChartableMetrics.ts
+++ b/utilities/ChartableMetrics.ts
@@ -4,7 +4,27 @@ import { op } from "arquero";
 import type { ColumnTable } from "arquero";
 import type { SortOrder } from "utilities/ChartOptions";
 import type DistrictData from "utilities/DistrictData";
-import type { CurrencyNormalization, StaffingNormalization } from "utilities/normalizations";
+import type {
+  CurrencyNormalization,
+  StaffingNormalization,
+} from "utilities/normalizations";
+
+// Datasets this module reads, so a dashboard using it can declare
+// `...METRICS_DATASETS` instead of hand-listing frames it never names. Keep
+// this next to the code that reads them: if a new accessor is used below, the
+// dataset belongs here, and every dashboard picks it up automatically.
+//
+// expenditures + compensation -> gf_expenditures; revenues -> gf_revenues;
+// staffingSummary -> budget_items, budgeted_fte, s275_summary;
+// all_class_ofs -> fundedEnrollment, gf_expenditures, gf_revenues.
+export const METRICS_DATASETS = [
+  "gf_expenditures",
+  "gf_revenues",
+  "budget_items",
+  "budgeted_fte",
+  "s275_summary",
+  "fundedEnrollment",
+] as const;
 
 export type FacetInfo = {
   code: string;
@@ -204,7 +224,10 @@ export function extractRawExpenditures(df: ColumnTable, facetColumn: string) {
   return data;
 }
 
-export function extractRawS275Staffing(df: ColumnTable, facetColumn: string = "duty_root") {
+export function extractRawS275Staffing(
+  df: ColumnTable,
+  facetColumn: string = "duty_root",
+) {
   const facetCodeColumn = `${facetColumn}_code`;
   const data = df.groupby("class_of", facetCodeColumn).rollup({
     finalSalary: (d) => op.sum(d.c_est_total_final_salary),
@@ -232,14 +255,7 @@ export function toFacetedCharatbleDataset(
     .select(aq.not(aq.startswith("_pivot_name_hack_")));
 
   const names = getDataColumnNames(pdata);
-  return toChartableDataset(
-    districtData,
-    pdata,
-    settings,
-    [],
-    names,
-    [],
-  );
+  return toChartableDataset(districtData, pdata, settings, [], names, []);
 }
 
 function extractRawEnrollment(
@@ -294,7 +310,12 @@ export function toFacetedCharatbleEnrollmentDataset(
     breakdownCodeColumn !== facetCodeColumn &&
     breakdownCodeColumn !== "student_group_code";
   const df = extractRawEnrollment(
-    filteredDf, facet, metricColumn, breakdownCodeColumn, xColumn, extraSeriesDimCol,
+    filteredDf,
+    facet,
+    metricColumn,
+    breakdownCodeColumn,
+    xColumn,
+    extraSeriesDimCol,
   );
 
   // composite_key shape:
@@ -307,7 +328,7 @@ export function toFacetedCharatbleEnrollmentDataset(
   // appending `<seriesCode>` after the facet code, where the seriesCode
   // is the rest of the composite_key after the leading facet segment.
   const withComposite = df
-    .filter(d => d.grade != "All Grades")
+    .filter((d) => d.grade != "All Grades")
     .derive({ _metric: aq.escape((d) => d[metricColumn]) })
     .derive({
       composite_key: aq.escape((d) => {
@@ -368,19 +389,21 @@ export function toFacetedCharatbleAssessmentDataset(
   metricColumn: string = "pct_met_standard_withdat",
 ) {
   const facetCodeColumn = `${facet}_code`;
-  const seriesCodeColumns = ASSESSMENT_CODE_COLUMNS.filter(c => c !== facetCodeColumn);
+  const seriesCodeColumns = ASSESSMENT_CODE_COLUMNS.filter(
+    (c) => c !== facetCodeColumn,
+  );
 
   // Stage the chosen metric under a known name so the rollup expression
   // can reference it without depending on dynamic column-name parsing.
   // Then create the composite pivot key: facet code first, then the
   // remaining dimensions.
-  const withComposite = filteredDf
-    .derive({
-      _metric: aq.escape((d) => d[metricColumn]),
-      composite_key: aq.escape(d =>
-        `${d[facetCodeColumn]}_${seriesCodeColumns.map(c => d[c]).join("_")}`
-      ),
-    });
+  const withComposite = filteredDf.derive({
+    _metric: aq.escape((d) => d[metricColumn]),
+    composite_key: aq.escape(
+      (d) =>
+        `${d[facetCodeColumn]}_${seriesCodeColumns.map((c) => d[c]).join("_")}`,
+    ),
+  });
 
   // Pivot by composite key, averaging the chosen metric per group.
   // Multiply by 100 so the chart axis renders as a percent. The output
@@ -395,12 +418,5 @@ export function toFacetedCharatbleAssessmentDataset(
     .select(aq.not(aq.startswith("_pivot_name_hack_")));
 
   const names = getDataColumnNames(pdata);
-  return toChartableDataset(
-    districtData,
-    pdata,
-    settings,
-    [],
-    names,
-    [],
-  );
+  return toChartableDataset(districtData, pdata, settings, [], names, []);
 }

--- a/utilities/ChartableVitals.ts
+++ b/utilities/ChartableVitals.ts
@@ -1,7 +1,11 @@
 import * as aq from "arquero";
 import { op } from "arquero";
 
-import { toChartableDataset, toFacetedCharatbleDataset, getDataColumnNames } from "utilities/ChartableMetrics";
+import {
+  toChartableDataset,
+  toFacetedCharatbleDataset,
+  getDataColumnNames,
+} from "utilities/ChartableMetrics";
 import DistrictData from "utilities/DistrictData";
 
 import type { ColumnTable } from "arquero";
@@ -10,6 +14,28 @@ import type { SortOrder, SortType } from "utilities/ChartOptions";
 import type { DistrictDataMap } from "app/finance/_providers/DistrictDataProvider";
 import type { VitalsSettings } from "app/finance/vitals/VitalsDashboard";
 import type { CurrencyNormalization } from "utilities/normalizations";
+
+// Datasets this module reads; see METRICS_DATASETS in ChartableMetrics for
+// why the declaration lives beside the code rather than in each dashboard.
+//
+// Worked out transitively, not from the accessors' own bodies: balances()
+// and cashflow() both reach budgetary_comparison through revisedGfSummary().
+//
+// staffingSummary -> budget_items, budgeted_fte, s275_summary;
+// compensation -> gf_expenditures;
+// cashflow -> gf_expenditures, gf_revenues, budgetary_comparison;
+// balances -> actuals_items, budget_items, budgetary_comparison;
+// fundedEnrollmentSummary -> budget_items, fundedEnrollment.
+export const VITALS_DATASETS = [
+  "budget_items",
+  "budgeted_fte",
+  "s275_summary",
+  "gf_expenditures",
+  "gf_revenues",
+  "actuals_items",
+  "fundedEnrollment",
+  "budgetary_comparison",
+] as const;
 
 function extractRawVitals(districtData, ccddd) {
   return districtData
@@ -91,14 +117,14 @@ function extractFacetsSortedByLatestAmount(
   facetColumn: string,
   sortColumn: string,
   sortOrder: SortOrder,
-) : Array<FacetInfo> {
+): Array<FacetInfo> {
   const facetCodeColumn = `${facetColumn}_code`;
   const sorted = df
-    .filter(d => d.class_of === op.max(d.class_of))  // Only get latest year.
+    .filter((d) => d.class_of === op.max(d.class_of)) // Only get latest year.
     .groupby(facetColumn, facetCodeColumn)
     .params({ sortCol: sortColumn })
-    .rollup({ sortval: (d, $) => op.sum(d[$.sortCol]) })  // Sum up across non-facet categories
-    .orderby(aq.desc('sortval'));
+    .rollup({ sortval: (d, $) => op.sum(d[$.sortCol]) }) // Sum up across non-facet categories
+    .orderby(aq.desc("sortval"));
 
   const facetInfo = sorted
     .derive({
@@ -116,7 +142,7 @@ function extractFacetsSortedByAbsMedianVariance(
   df: ColumnTable,
   facetColumn: string,
   sortOrder: SortOrder,
-) : Array<FacetInfo> {
+): Array<FacetInfo> {
   const facetCodeColumn = `${facetColumn}_code`;
 
   // Calculate variance for sort order.
@@ -160,18 +186,21 @@ export function extractFacets(
   districtDataMap,
   allSettings,
   facet,
-  sortType : SortType,
-  sortOrder : SortOrder,
+  sortType: SortType,
+  sortOrder: SortOrder,
   extractor = DistrictData.prototype.filteredExpenditures,
   dataTransform = toFacetedCharatbleDataset,
-  valueColumn : string = "amount",
+  valueColumn: string = "amount",
   skipVitalsContext = false,
 ) {
   const allDatasets = new Array<ColumnTable>();
   let fullFacetOrder;
   for (const expenditureSettings of allSettings) {
     const districtData = districtDataMap[expenditureSettings.ccddd];
-    const filteredExpenditures = extractor.call(districtData, expenditureSettings);
+    const filteredExpenditures = extractor.call(
+      districtData,
+      expenditureSettings,
+    );
 
     const data = dataTransform(
       districtData,
@@ -182,7 +211,7 @@ export function extractFacets(
 
     allDatasets.push(data);
     if (fullFacetOrder === undefined) {
-      if (sortType === 'variance') {
+      if (sortType === "variance") {
         fullFacetOrder = extractFacetsSortedByAbsMedianVariance(
           filteredExpenditures,
           facet,
@@ -229,8 +258,9 @@ export function extractFacets(
   // straight line across them. We only fill the interior — older years
   // unique to one dataset (e.g. vitals back to 2002) stay excluded by
   // the inner join above.
-  const years = (data.array("class_of") as Array<number | null>)
-    .filter((y): y is number => y !== null && y !== undefined);
+  const years = (data.array("class_of") as Array<number | null>).filter(
+    (y): y is number => y !== null && y !== undefined,
+  );
   if (years.length > 0) {
     const minYear = Math.min(...years);
     const maxYear = Math.max(...years);
@@ -250,4 +280,3 @@ export function extractFacets(
 
   return { data, fullFacetOrder };
 }
-

--- a/utilities/DistrictData.tsx
+++ b/utilities/DistrictData.tsx
@@ -1,6 +1,15 @@
 import { op } from "arquero";
 import * as aq from "arquero";
-import { fetchDataset } from "utilities/client/FetchData";
+
+import {
+  loadDatasets,
+  registerNormalizer,
+} from "utilities/client/DistrictDatasets";
+
+import type {
+  DatasetBundle,
+  DatasetName,
+} from "utilities/client/DistrictDatasets";
 import ALL_ASSESSMENT_TYPES from "utilities/domain/assessment_types";
 import ALL_ENROLLMENT_STUDENT_GROUPS from "utilities/domain/enrollment_student_groups";
 import ALL_GRADE_LEVELS from "utilities/domain/grade_levels";
@@ -256,7 +265,8 @@ function deriveStaffClassColumns(df) {
       employmentClassCodeForDutyRoot(d.duty_root_code),
     ),
     employment_class: aq.escape(
-      (d) => EMPLOYMENT_CLASS_LABEL[employmentClassForDutyRoot(d.duty_root_code)],
+      (d) =>
+        EMPLOYMENT_CLASS_LABEL[employmentClassForDutyRoot(d.duty_root_code)],
     ),
     staff_category_code: aq.escape((d) =>
       staffCategoryCodeForDutyRoot(d.duty_root_code),
@@ -293,70 +303,85 @@ function combineCommonActivities(df, combiner) {
 // groupings of information and calculations.
 //
 // Data is joinable on the 'class_of' and 'data_type' columns.
+// Per-dataset normalization, registered with the dataset cache so it runs once
+// per district-dataset rather than once per DistrictData. Synthetic activity
+// codes collapse categories that OSPI split over the years; the staff-class
+// columns are derived from the duty root so both the S-275 actuals and the
+// F-195 budget can be filtered and faceted the same way.
+registerNormalizer("gf_expenditures", (df) =>
+  combineCommonActivities(df, combineActivitiesF19x),
+);
+registerNormalizer("s275_summary", (df) =>
+  deriveStaffClassColumns(combineCommonActivities(df, combineActivitiesS275)),
+);
+registerNormalizer("budgeted_fte", (df) =>
+  deriveStaffClassColumns(
+    combineCommonActivities(df, combineActivitiesBudgetedFte),
+  ),
+);
+
 export default class DistrictData {
-  private enrollment_df: ColumnTable;
-  private fundedEnrollment_df: ColumnTable;
-  private assessment_df: ColumnTable;
-  private sqss_df: ColumnTable;
-  private gf_expenditure_df: ColumnTable;
-  private gf_revenue_df: ColumnTable;
-  private budget_items_df: ColumnTable;
-  private actuals_items_df: ColumnTable;
-  private s275_summary_df: ColumnTable;
-  private budgeted_fte_df: ColumnTable;
-  private budgetary_comparison_df: ColumnTable;
-  private all_class_ofs_df: ColumnTable;
+  private bundle: DatasetBundle;
+  private all_class_ofs_cache: ColumnTable | null = null;
 
-  constructor(
-    enrollment_df,
-    fundedEnrollment_df,
-    assessment_df,
-    sqss_df,
-    gf_expenditure_df,
-    gf_revenue_df,
-    budget_items_df,
-    actuals_items_df,
-    s275_summary_df,
-    budgeted_fte_df,
-    budgetary_comparison_df,
-  ) {
-    this.enrollment_df = enrollment_df;
-    this.fundedEnrollment_df = fundedEnrollment_df;
-    this.assessment_df = assessment_df;
-    this.sqss_df = sqss_df;
-    this.gf_expenditure_df = gf_expenditure_df;
-    this.gf_revenue_df = gf_revenue_df;
-    this.budget_items_df = budget_items_df;
-    this.actuals_items_df = actuals_items_df;
-    this.s275_summary_df = s275_summary_df;
-    this.budgeted_fte_df = budgeted_fte_df;
-    this.budgetary_comparison_df = budgetary_comparison_df;
+  constructor(bundle: DatasetBundle) {
+    this.bundle = bundle;
+  }
 
-    // Create synthetic activities for categories that have split over the
-    // years such as Teaching + Professional Learning. In this case, it
-    // replaces the activity code 27 and 34 with their summation labeled
-    // with a synthetic activity code.
-    this.gf_expenditure_df = combineCommonActivities(
-      this.gf_expenditure_df,
-      combineActivitiesF19x,
-    );
-    this.s275_summary_df = combineCommonActivities(
-      this.s275_summary_df,
-      combineActivitiesS275,
-    );
-    this.budgeted_fte_df = combineCommonActivities(
-      this.budgeted_fte_df,
-      combineActivitiesBudgetedFte,
-    );
+  // A dashboard reaching for a dataset it did not declare is a bug in its
+  // declaration, and the failure has to be loud: falling back to an empty
+  // frame would draw a plausible-looking chart with nothing in it, which is
+  // far harder to notice than a crash.
+  private require(name: DatasetName): ColumnTable {
+    const df = this.bundle[name];
+    if (!df) {
+      throw new Error(
+        `DistrictData needs the "${name}" dataset, which this dashboard did ` +
+          `not declare. Add it to the dashboard's datasets list (or to the ` +
+          `DATASETS constant of the helper that reads it).`,
+      );
+    }
+    return df;
+  }
 
-    // Derive employment class (certificated/classified, 2-way -- the Staffing
-    // FILTER) and staff category (the finer 6-way OSPI breakdown -- the Staffing
-    // "Staff Category" FACET) from the duty ROOT code (OSPI's authoritative rule
-    // -- see utilities/domain/duty_roots). Both the S-275 actuals and the F-195
-    // budget carry duty_root_code, so these are filterable AND facetable
-    // dimensions on the Staffing dashboard for both.
-    this.s275_summary_df = deriveStaffClassColumns(this.s275_summary_df);
-    this.budgeted_fte_df = deriveStaffClassColumns(this.budgeted_fte_df);
+  // Getters rather than fields so every method below reads unchanged while
+  // the underlying frames stay lazily required.
+  private get enrollment_df() {
+    return this.require("enrollment");
+  }
+  private get fundedEnrollment_df() {
+    return this.require("fundedEnrollment");
+  }
+  private get assessment_df() {
+    return this.require("assessment");
+  }
+  private get gf_expenditure_df() {
+    return this.require("gf_expenditures");
+  }
+  private get gf_revenue_df() {
+    return this.require("gf_revenues");
+  }
+  private get budget_items_df() {
+    return this.require("budget_items");
+  }
+  private get actuals_items_df() {
+    return this.require("actuals_items");
+  }
+  private get s275_summary_df() {
+    return this.require("s275_summary");
+  }
+  private get budgeted_fte_df() {
+    return this.require("budgeted_fte");
+  }
+  private get budgetary_comparison_df() {
+    return this.require("budgetary_comparison");
+  }
+
+  private get all_class_ofs_df(): ColumnTable {
+    // Computed on demand: it spans three datasets, so eagerly deriving it
+    // would drag them into every dashboard whether or not it asks for a year
+    // list. Cached because callers hit it per render.
+    if (this.all_class_ofs_cache) return this.all_class_ofs_cache;
 
     const minMaxDf = minMaxClassOf(this.fundedEnrollment_df)
       .concat(minMaxClassOf(this.gf_expenditure_df))
@@ -371,72 +396,24 @@ export default class DistrictData {
       all_class_ofs.push(year);
     }
 
-    this.all_class_ofs_df = aq.table({ class_of: all_class_ofs });
+    this.all_class_ofs_cache = aq.table({ class_of: all_class_ofs });
+    return this.all_class_ofs_cache;
   }
 
-  static async loadFromGcs(ccddd) {
-    const [
-      enrollment_df,
-      fundedEnrollment_df,
-      assessment_df,
-      sqss_df,
-      gf_expenditure_df,
-      gf_revenue_df,
-      budget_items_df,
-      actuals_items_df,
-      s275_summary_df,
-      budgeted_fte_df,
-      budgetary_comparison_df,
-    ] = await Promise.all([
-      fetchDataset(ccddd, "enrollment"),
-      fetchDataset(ccddd, "fundedEnrollment"),
-      fetchDataset(ccddd, "assessment"),
-      fetchDataset(ccddd, "sqss"),
-      fetchDataset(ccddd, "gf_expenditures"),
-      fetchDataset(ccddd, "gf_revenues"),
-      fetchDataset(ccddd, "budget_items"),
-      fetchDataset(ccddd, "actuals_items"),
-      fetchDataset(ccddd, "s275_summary"),
-      // Budgeted FTE (F-195) is a newer dataset. Degrade gracefully if it can't
-      // be fetched (e.g. the Cloud Function hasn't been deployed yet, or a
-      // district has no F-195 filing) with an empty, correctly-shaped frame so
-      // the rest of the finance data still loads -- the Staffing dashboard then
-      // simply shows no Budget overlay rather than breaking every dashboard.
-      fetchDataset(ccddd, "budgeted_fte").catch(() =>
-        aq.table({
-          class_of: [],
-          program_code: [],
-          activity_code: [],
-          duty_root_code: [],
-          fte: [],
-        }),
-      ),
-      // Mid-year revised budget (F-196 Budgetary Comparison) is a newer
-      // dataset. Same graceful degrade as budgeted_fte: an empty frame just
-      // means no Revised Budget series on the charts.
-      fetchDataset(ccddd, "budgetary_comparison").catch(() =>
-        aq.table({
-          class_of: [],
-          fund: [],
-          section: [],
-          item_code: [],
-          amount: [],
-        }),
-      ),
-    ]);
-    return new DistrictData(
-      enrollment_df,
-      fundedEnrollment_df,
-      assessment_df,
-      sqss_df,
-      gf_expenditure_df,
-      gf_revenue_df,
-      budget_items_df,
-      actuals_items_df,
-      s275_summary_df,
-      budgeted_fte_df,
-      budgetary_comparison_df,
-    );
+  static async loadFromGcs(ccddd: number, datasets: readonly DatasetName[]) {
+    return new DistrictData(await loadDatasets(ccddd, datasets));
+  }
+
+  /**
+   * Whether every named dataset is present in this instance.
+   *
+   * The provider rebuilds DistrictData as dashboards ask for wider dataset
+   * sets, so a district being "loaded" is not the same as being loaded with
+   * what the current dashboard needs -- switching from a narrower tab would
+   * otherwise render against a bundle missing a frame.
+   */
+  hasAll(names: readonly DatasetName[]): boolean {
+    return names.every((n) => this.bundle[n] !== undefined);
   }
 
   // Direct accessors

--- a/utilities/client/DistrictDatasets.test.ts
+++ b/utilities/client/DistrictDatasets.test.ts
@@ -1,0 +1,137 @@
+import * as aq from "arquero";
+
+import { fetchDataset } from "utilities/client/FetchData";
+
+// arquero is stubbed repo-wide (__mocks__/arquero.ts), so these tests use
+// sentinel objects as "frames". The cache does not inspect them -- it only
+// has to hand back the same one, exactly once per district-dataset.
+
+import {
+  loadDataset,
+  loadDatasets,
+  registerNormalizer,
+  resetDatasetCacheForTest,
+} from "./DistrictDatasets";
+
+jest.mock("utilities/client/FetchData", () => ({
+  fetchDataset: jest.fn(),
+}));
+
+const mockFetch = fetchDataset as jest.MockedFunction<typeof fetchDataset>;
+
+type Frame =
+  ReturnType<typeof fetchDataset> extends Promise<infer T> ? T : never;
+
+function frame(id: string) {
+  return { id } as unknown as Frame;
+}
+
+describe("loadDataset", () => {
+  beforeEach(() => {
+    resetDatasetCacheForTest();
+    mockFetch.mockReset();
+  });
+
+  it("fetches a district-dataset pair only once", async () => {
+    mockFetch.mockResolvedValue(frame("a"));
+
+    await loadDataset(17001, "gf_expenditures");
+    await loadDataset(17001, "gf_expenditures");
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("shares one request between concurrent callers", async () => {
+    let release: (t: unknown) => void = () => {};
+    mockFetch.mockReturnValue(
+      new Promise((resolve) => {
+        release = resolve;
+      }) as ReturnType<typeof fetchDataset>,
+    );
+
+    const a = loadDataset(17001, "assessment");
+    const b = loadDataset(17001, "assessment");
+    release(frame("a"));
+    await Promise.all([a, b]);
+
+    // The point of caching promises rather than values: a second caller
+    // arriving mid-flight must not start a second download.
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps districts separate", async () => {
+    mockFetch.mockResolvedValue(frame("a"));
+
+    await loadDataset(17001, "sqss");
+    await loadDataset(31005, "sqss");
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not cache a failure, so a later attempt can retry", async () => {
+    mockFetch.mockRejectedValueOnce(new Error("boom"));
+    await expect(loadDataset(17001, "enrollment")).rejects.toThrow("boom");
+
+    mockFetch.mockResolvedValueOnce(frame("b"));
+    await expect(loadDataset(17001, "enrollment")).resolves.toBeDefined();
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("falls back for datasets that may legitimately not exist", async () => {
+    mockFetch.mockRejectedValue(new Error("not deployed"));
+
+    // budgeted_fte is optional: a district with no F-195 filing must not break
+    // every dashboard that merely overlays it. The fallback builds an empty
+    // frame via aq.table, which is what we can observe under the stub.
+    await expect(loadDataset(17001, "budgeted_fte")).resolves.not.toThrow();
+    expect(aq.table).toHaveBeenCalledWith(expect.objectContaining({ fte: [] }));
+  });
+
+  it("does not invent a fallback for a required dataset", async () => {
+    mockFetch.mockRejectedValue(new Error("boom"));
+
+    // The opposite case, and the more important one: a dataset with no
+    // fallback must surface the failure rather than quietly resolving empty.
+    await expect(loadDataset(17001, "gf_expenditures")).rejects.toThrow("boom");
+  });
+
+  it("applies a registered normalizer once per district-dataset", async () => {
+    mockFetch.mockResolvedValue(frame("a"));
+    const normalized = frame("normalized");
+    const normalize = jest.fn(() => normalized);
+    registerNormalizer("actuals_items", normalize);
+
+    const first = await loadDataset(17001, "actuals_items");
+    const second = await loadDataset(17001, "actuals_items");
+
+    expect(first).toBe(normalized);
+    expect(second).toBe(normalized);
+    // Normalizing in the cache rather than per DistrictData is the whole
+    // point: two dashboards sharing a dataset must not redo the work.
+    expect(normalize).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("loadDatasets", () => {
+  beforeEach(() => {
+    resetDatasetCacheForTest();
+    mockFetch.mockReset();
+    mockFetch.mockResolvedValue(frame("a"));
+  });
+
+  it("returns a bundle keyed by dataset name", async () => {
+    const bundle = await loadDatasets(17001, ["enrollment", "gf_revenues"]);
+    expect(Object.keys(bundle).sort()).toEqual(["enrollment", "gf_revenues"]);
+  });
+
+  it("requests nothing beyond what was asked for", async () => {
+    await loadDatasets(17001, ["enrollment"]);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(mockFetch).toHaveBeenCalledWith(17001, "enrollment");
+  });
+
+  it("de-duplicates a repeated name in one call", async () => {
+    await loadDatasets(17001, ["sqss", "sqss"]);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/utilities/client/DistrictDatasets.ts
+++ b/utilities/client/DistrictDatasets.ts
@@ -1,0 +1,179 @@
+// Per-dataset fetching and caching for the finance dashboards.
+//
+// The district data is eleven independent datasets, but they used to be
+// fetched as one all-or-nothing batch, so every dashboard blocked on ~18 MB
+// (for Seattle) regardless of what it read. Assessment and SQSS alone are
+// 9.5 MB that only the Assessments dashboard has any use for.
+//
+// Caching here rather than in the provider, and caching PROMISES rather than
+// resolved tables, buys three things:
+//   * two dashboards asking for the same dataset while it is in flight share
+//     one request instead of racing,
+//   * a dataset already loaded for another tab resolves immediately, which is
+//     what keeps tab-to-tab switching fast,
+//   * the "have we started this yet" bookkeeping is the cache itself, rather
+//     than a second set that can drift out of sync with it.
+//
+// Normalization (synthetic activities, derived staff-class columns) happens
+// here too, so it runs once per district-dataset instead of once per
+// DistrictData, and every consumer sees the same shape.
+
+import * as aq from "arquero";
+
+import { fetchDataset } from "utilities/client/FetchData";
+
+import type { ColumnTable } from "arquero";
+
+export const DATASET_NAMES = [
+  "enrollment",
+  "fundedEnrollment",
+  "assessment",
+  "sqss",
+  "gf_expenditures",
+  "gf_revenues",
+  "budget_items",
+  "actuals_items",
+  "s275_summary",
+  "budgeted_fte",
+  "budgetary_comparison",
+] as const;
+
+export type DatasetName = (typeof DATASET_NAMES)[number];
+
+/** Datasets a dashboard asked for. Anything not requested is absent. */
+export type DatasetBundle = Partial<Record<DatasetName, ColumnTable>>;
+
+// Datasets that may legitimately not exist for a district (newer Cloud
+// Function endpoints, or a district with no such filing). These resolve to an
+// empty, correctly-shaped frame so one missing dataset cannot break a whole
+// dashboard -- the charts that read them simply have no series.
+//
+// This is ONLY for datasets that may genuinely be absent. A dataset a
+// dashboard forgot to declare must fail loudly instead (see DistrictData),
+// because a silently empty chart is a worse bug than a crash.
+const EMPTY_FALLBACKS: Partial<Record<DatasetName, () => ColumnTable>> = {
+  budgeted_fte: () =>
+    aq.table({
+      class_of: [],
+      program_code: [],
+      activity_code: [],
+      duty_root_code: [],
+      fte: [],
+    }),
+  budgetary_comparison: () =>
+    aq.table({
+      class_of: [],
+      fund: [],
+      section: [],
+      item_code: [],
+      amount: [],
+    }),
+};
+
+type Normalizer = (df: ColumnTable) => ColumnTable;
+
+// Registered by DistrictData, which owns the domain rules (synthetic activity
+// codes, duty-root-derived staff class). Kept as a registration rather than an
+// import so this module does not depend on DistrictData and create a cycle.
+const normalizers = new Map<DatasetName, Normalizer>();
+
+export function registerNormalizer(name: DatasetName, fn: Normalizer) {
+  normalizers.set(name, fn);
+}
+
+// How long to wait for an idle moment before prefetching anyway.
+const PREFETCH_DEADLINE_MS = 2000;
+
+const cache = new Map<string, Promise<ColumnTable>>();
+
+function key(ccddd: number, name: DatasetName) {
+  return `${ccddd}:${name}`;
+}
+
+/** Fetch one dataset, or hand back the in-flight/completed request for it. */
+export function loadDataset(
+  ccddd: number,
+  name: DatasetName,
+): Promise<ColumnTable> {
+  const cacheKey = key(ccddd, name);
+  const hit = cache.get(cacheKey);
+  if (hit) return hit;
+
+  const pending = fetchDataset(ccddd, name)
+    .catch((err) => {
+      const fallback = EMPTY_FALLBACKS[name];
+      if (!fallback) throw err;
+      console.warn(
+        `[DistrictDatasets] ${name} unavailable for ${ccddd}; ` +
+          `continuing with an empty frame.`,
+        err,
+      );
+      return fallback();
+    })
+    .then((df) => normalizers.get(name)?.(df) ?? df);
+
+  // A failed fetch of a dataset with no fallback must not poison the cache,
+  // or the dashboard can never recover without a reload.
+  pending.catch(() => {
+    if (cache.get(cacheKey) === pending) cache.delete(cacheKey);
+  });
+
+  cache.set(cacheKey, pending);
+  return pending;
+}
+
+/** Fetch exactly the datasets asked for, in parallel. */
+export async function loadDatasets(
+  ccddd: number,
+  names: readonly DatasetName[],
+): Promise<DatasetBundle> {
+  const wanted = [...new Set(names)];
+  const frames = await Promise.all(wanted.map((n) => loadDataset(ccddd, n)));
+  const bundle: DatasetBundle = {};
+  wanted.forEach((n, i) => {
+    bundle[n] = frames[i];
+  });
+  return bundle;
+}
+
+/**
+ * Warm the datasets this district has not loaded yet, without blocking.
+ *
+ * Requesting only what a dashboard needs makes its first paint cheap, but
+ * would make the first switch to a heavier tab slower than loading everything
+ * up front did. Filling the rest in once the page is idle keeps that switch
+ * warm; failures are ignored because nothing is waiting on them.
+ */
+export function prefetchRemaining(
+  ccddd: number,
+  exclude: readonly DatasetName[],
+) {
+  const skip = new Set(exclude);
+  const rest = DATASET_NAMES.filter(
+    (n) => !skip.has(n) && !cache.has(key(ccddd, n)),
+  );
+  if (rest.length === 0) return;
+
+  const run = () => {
+    for (const name of rest) loadDataset(ccddd, name).catch(() => {});
+  };
+
+  // The timeout is not optional: requestIdleCallback with no deadline can be
+  // deferred indefinitely on a page that never goes idle (the Money Flows
+  // Sankey is one), and the prefetch would then simply never happen.
+  const idle = (
+    globalThis as {
+      requestIdleCallback?: (
+        cb: () => void,
+        opts?: { timeout: number },
+      ) => void;
+    }
+  ).requestIdleCallback;
+  if (idle) idle(run, { timeout: PREFETCH_DEADLINE_MS });
+  else setTimeout(run, PREFETCH_DEADLINE_MS);
+}
+
+/** Test seam: forget everything cached. */
+export function resetDatasetCacheForTest() {
+  cache.clear();
+}


### PR DESCRIPTION
Two follow-ups on the Salaries page.

## 1. The doubled nav (the original fix)

`SalariesPage` rendered its own `<FinanceSubNav />`. No other finance page does — the nav comes from `PrimaryNav` via the root layout — so the page drew a second bar under the first.

The Salaries link was also in the wrong component: `PrimaryNav` **imports** `FinanceSubNav` but never renders it; the links it draws come from `FINANCE_NAV_CONFIGS`. So the tab never appeared in the nav on any page. That corrects something I said earlier — the live site's missing Salaries link was not a stale deploy, the link was never in the rendered nav.

Entry moved to `FINANCE_NAV_CONFIGS`, duplicate render dropped, and the edit to `FinanceSubNav` reverted rather than leaving a misleading link in a component nothing renders.

## 2. A settings drawer, matching the other dashboards

The page had two inline selectors bolted above the chart. It now uses the shared `SettingsLayout` drawer, so it configures like Staffing and encodes state in the URL the same way:

| box | settings |
|---|---|
| context | school year, people per row |
| dataset | district, duty title filter |

Splitting into `SalariesPage` (deserializes the URL) and `SalariesDashboard` (renders) mirrors the other dashboards.

Two deliberate departures:

- **It does not go through `EnsureDistrictData`.** That waits on `DistrictData` — ten datasets this page never reads — and blocks first paint on all of them. The page fetches the one per-employee dataset it needs itself.
- **The dataset box does not reuse `DatasetSettingsContents`.** That renders currency and staffing normalization selectors and the filter-grouping selector, none of which mean anything for a chart that is always dollars-per-person and applies a single filter.

## Verified against the deployed dataset

`s275_salaries` is live now, so this was checked end to end against real data rather than a fixture (via a production build, since dev points at the Firebase emulator):

- SPS 2024-25 loads **7,156 people / 6,362 FTE / $684.0M / 34 duty titles**
- unchecking the **teacher** category → **2,511 people / $252.7M / 26 duty titles**, layout reflows
- **2019-20** → **2,553 people / $202.0M**
- **2,500 per row** → five rows become three
- all three compose in the URL: `?d=c.17001~…~d.S0AeCAWAAw&c=y.2019-2020~w.2500`

One visible nav bar throughout, with Salaries highlighted as current.

`tsc` clean, 206 tests pass, build compiles and prerenders 35 pages, lint clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)